### PR TITLE
Add docstring linting to the project

### DIFF
--- a/lta/config.py
+++ b/lta/config.py
@@ -1,4 +1,5 @@
 # config.py
+"""Module to provide configuration support."""
 
 import os
 from typing import cast, Dict, Optional, Sequence, Union
@@ -8,6 +9,46 @@ KeySpec = Union[str, Sequence[str], OptionalDict]
 
 
 def from_environment(keys: KeySpec) -> Dict[str, str]:
+    """
+    Obtain configuration values from the OS environment.
+
+    keys - Specify the configuration values to obtain.
+
+           This can be a string, specifying a single key, such as:
+
+               config_dict = from_environment("LANGUAGE")
+
+           This can be a list of strings, specifying multiple keys,
+           such as:
+
+               config_dict = from_environment(["HOME", "LANGUAGE"])
+
+           This can be a dictionary that provides some default values,
+           and will accept overrides from the environment:
+
+               default_config = {
+                   "HOST": "localhost",
+                   "PORT": "8080",
+                   "REQUIRED_FROM_ENVIRONMENT": None
+               }
+               config_dict = from_environment(default_config)
+
+           Note in this case that if 'HOST' or 'PORT' were defined in the
+           environment, those values would be returned in config_dict. If
+           the values were not defined in the environment, the default values
+           from default_config would be returned in config_dict.
+
+           Also note, that is 'REQUIRED_FROM_ENVIRONMENT' is not defined,
+           an OSError will be raised. The sentinel value of None indicates
+           that the configuration parameter MUST be sourced from the
+           environment.
+
+    Returns a dictionary mapping configuration keys to configuration values.
+
+    If a configuration value is requested and no default value is provided
+    (via a dict), then an OSError will be raised to indicate that the
+    component's configuration is incomplete due to missing data from the OS.
+    """
     if isinstance(keys, str):
         keys = {keys: None}
     elif isinstance(keys, list):

--- a/lta/config.py
+++ b/lta/config.py
@@ -38,7 +38,7 @@ def from_environment(keys: KeySpec) -> Dict[str, str]:
            the values were not defined in the environment, the default values
            from default_config would be returned in config_dict.
 
-           Also note, that is 'REQUIRED_FROM_ENVIRONMENT' is not defined,
+           Also note, that if 'REQUIRED_FROM_ENVIRONMENT' is not defined,
            an OSError will be raised. The sentinel value of None indicates
            that the configuration parameter MUST be sourced from the
            environment.

--- a/lta/log_format.py
+++ b/lta/log_format.py
@@ -1,4 +1,19 @@
 # log_format.py
+"""
+Module to provide support for structured logging.
+
+Example code to enable structured logging might look as follows:
+
+    structured_formatter = StructuredFormatter(
+        component_type='Transmogrifier',
+        component_name='transmog-node-1',
+        ndjson=True)
+    stream_handler = logging.StreamHandler()
+    stream_handler.setFormatter(structured_formatter)
+    root_logger = logging.getLogger(None)
+    root_logger.setLevel(logging.NOTSET)
+    root_logger.addHandler(stream_handler)
+"""
 
 from datetime import datetime
 import json
@@ -7,10 +22,24 @@ from typing import Optional
 
 
 class StructuredFormatter(Formatter):
+    """
+    StructuredFormatter is a Formatter for structured logging.
+
+    LogRecord objects are formatted as JSON. Under the default configuration,
+    a StructuredFormatter will render these as NDJSON (http://ndjson.org/)
+    """
+
     def __init__(self,
                  component_name: Optional[str] = None,
                  component_type: Optional[str] = None,
                  ndjson: bool = True) -> None:
+        """
+        Create a StructuredFormatter object.
+
+        component_name: Optional[str] - The name of the software component
+        component_type: Optional[str] - The type of the software component
+        ndjson: bool - Output as NDJSON; defaults to True.
+        """
         self.component_name = component_name
         self.component_type = component_type
         self.indent = None if ndjson else 4
@@ -18,6 +47,16 @@ class StructuredFormatter(Formatter):
         super(StructuredFormatter, self).__init__()
 
     def format(self, record: LogRecord) -> str:
+        """
+        Format a LogRecord object as a log message.
+
+        record - LogRecord object to be formatted
+
+        Returns a log message as a str. In the default configuration, this
+        is JSON on a single line (NDJSON). If the StructuredFormatter is
+        created with ndjson=False, then each log message will become a
+        pretty-printed block of JSON.
+        """
         # ensure our log message has an ISO 8601 timestamp
         data = {
             'timestamp': datetime.utcnow().isoformat()

--- a/lta/picker.py
+++ b/lta/picker.py
@@ -1,4 +1,5 @@
 # picker.py
+"""Module to implement the Picker component of the Long Term Archive."""
 
 import asyncio
 from datetime import datetime
@@ -28,7 +29,22 @@ EXPECTED_STATE = [
 
 
 class Picker:
+    """
+    Picker is a Long Term Archive component.
+
+    A Picker is responsible for choosing the files that need to be bundled
+    and sent to remote archival destinations. It requests work from the
+    LTA REST API and then queries the file catalog to determine which files
+    to add to the LTA REST API.
+    """
+
     def __init__(self, config: Dict[str, str], logger: Logger) -> None:
+        """
+        Create a Picker component.
+
+        config - A dictionary of required configuration values.
+        logger - The object the picker should use for logging.
+        """
         # validate provided configuration
         for name in EXPECTED_CONFIG:
             if name not in config:
@@ -52,6 +68,7 @@ class Picker:
             self.logger.info(f"{name} = {config[name]}")
 
     async def run(self) -> None:
+        """Perform the component's work cycle."""
         self.logger.info("Starting picker work cycle")
         # start the work cycle stopwatch
         self.last_work_begin_timestamp = datetime.utcnow().isoformat()
@@ -76,6 +93,7 @@ class Picker:
 
 
 async def patch_status_heartbeat(picker: Picker) -> bool:
+    """PATCH /status/picker to update LTA with a status heartbeat."""
     picker.logger.info("Sending status heartbeat")
     # determine which resource to PATCH
     status_url = urljoin(picker.lta_rest_url, "/status/picker")
@@ -106,6 +124,7 @@ async def patch_status_heartbeat(picker: Picker) -> bool:
 
 
 async def status_loop(picker: Picker) -> None:
+    """Run status heartbeat updates as an infinite loop."""
     picker.logger.info("Starting status loop")
     while True:
         # PATCH /status/picker
@@ -115,6 +134,7 @@ async def status_loop(picker: Picker) -> None:
 
 
 async def work_loop(picker: Picker) -> None:
+    """Run picker work cycles as an infinite loop."""
     picker.logger.info("Starting work loop")
     while True:
         # Do the work of the picker
@@ -124,6 +144,7 @@ async def work_loop(picker: Picker) -> None:
 
 
 def main() -> None:
+    """Configure a Picker component from the environment and set it running."""
     # obtain our configuration from the environment
     config = from_environment(EXPECTED_CONFIG)
     # configure structured logging for the application

--- a/lta/square.py
+++ b/lta/square.py
@@ -1,5 +1,7 @@
 # square.py
+"""Module to provide a simple example of a testable function."""
 
 
 def square(x: float) -> float:
+    """Return the square of a provided number."""
     return x * x

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ chardet==3.0.4
 coverage==4.5.2
 docutils==0.14
 flake8==3.6.0
+flake8-docstrings==1.3.0
+flake8-polyfill==1.0.2
 idna==2.8
 imagesize==1.1.0
 Jinja2==2.10
@@ -22,6 +24,7 @@ pip==18.1
 pluggy==0.8.0
 py==1.7.0
 pycodestyle==2.4.0
+pydocstyle==3.0.0
 pyflakes==2.0.0
 Pygments==2.3.1
 PyJWT==1.7.1
@@ -30,6 +33,7 @@ pytest==4.0.2
 pytest-asyncio==0.9.0
 pytest-cov==2.6.0
 pytest-mock==1.10.0
+pytest-mypy==0.3.2
 pytz==2018.9
 requests==2.21.0
 requests-futures==0.9.9

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test for The Long Term Archive and tools."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,65 +1,50 @@
-# test_square.py
+# test_config.py
+"""Unit tests for lta/config.py."""
 
 from lta.config import from_environment
 import pytest
 
 
 def test_from_environment_none():
-    """
-    Fail with a TypeError if we don't ask for any environment variables.
-    """
+    """Fail with a TypeError if we don't ask for any environment variables."""
     with pytest.raises(TypeError):
         from_environment(None)
 
 
 def test_from_environment_scalar():
-    """
-    Fail with a TypeError if we don't ask for any environment variables.
-    """
+    """Fail with a TypeError if we don't ask for any environment variables."""
     with pytest.raises(TypeError):
         from_environment(50)
 
 
 def test_from_environment_scalar_list():
-    """
-    Fail with a TypeError if we don't ask for any environment variables.
-    """
+    """Fail with a TypeError if we don't ask for any environment variables."""
     with pytest.raises(TypeError):
         from_environment([10, 20, 30, 40, 50])
 
 
 def test_from_environment_missing(monkeypatch):
-    """
-    Fail with an OSError if we ask for an environment variable that does not
-    exist.
-    """
+    """Fail with an OSError if we ask for an environment variable that does not exist."""
     with pytest.raises(OSError):
         monkeypatch.delenv("PAN_GALACTIC_GARGLE_BLASTER", raising=False)
         from_environment("PAN_GALACTIC_GARGLE_BLASTER")
 
 
 def test_from_environment_missing_list(monkeypatch):
-    """
-    Fail with an OSError if we ask for an environment variable that does not
-    exist on a list that we provide.
-    """
+    """Fail with an OSError if we ask for an environment variable that does not exist on a list that we provide."""
     with pytest.raises(OSError):
         monkeypatch.delenv("PAN_GALACTIC_GARGLE_BLASTER", raising=False)
         from_environment(["PAN_GALACTIC_GARGLE_BLASTER"])
 
 
 def test_from_environment_empty():
-    """
-    Return an empty dictionary if we ask for no environment variables.
-    """
+    """Return an empty dictionary if we ask for no environment variables."""
     obj = from_environment([])
     assert len(obj.keys()) == 0
 
 
 def test_from_environment_key(monkeypatch):
-    """
-    Return a dictionary with a single environment variable.
-    """
+    """Return a dictionary with a single environment variable."""
     monkeypatch.setenv("LANGUAGE", "ja_JP")
     obj = from_environment("LANGUAGE")
     assert len(obj.keys()) == 1
@@ -67,9 +52,7 @@ def test_from_environment_key(monkeypatch):
 
 
 def test_from_environment_list(monkeypatch):
-    """
-    Return a dictionary with a list of environment variables.
-    """
+    """Return a dictionary with a list of environment variables."""
     monkeypatch.setenv("HOME", "/home/tux")
     monkeypatch.setenv("LANGUAGE", "ja_JP")
     obj = from_environment(["HOME", "LANGUAGE"])
@@ -79,9 +62,7 @@ def test_from_environment_list(monkeypatch):
 
 
 def test_from_environment_dict(monkeypatch):
-    """
-    Return a dictionary where we override one default but leave the other.
-    """
+    """Return a dictionary where we override one default but leave the other."""
     EXPECTED_CONFIG = {
         'HOME': '/home/tux',
         'LANGUAGE': 'en_US'
@@ -95,9 +76,7 @@ def test_from_environment_dict(monkeypatch):
 
 
 def test_from_environment_dict_required(monkeypatch):
-    """
-    Return a dictionary where we require the environment to provide a value.
-    """
+    """Raise an error where we require the environment to provide a value."""
     with pytest.raises(OSError):
         EXPECTED_CONFIG = {
             'HOME': None,

--- a/tests/test_log_format.py
+++ b/tests/test_log_format.py
@@ -1,20 +1,26 @@
 # test_log_format.py
+"""Unit tests for lta/log_format.py."""
 
 from lta.log_format import StructuredFormatter
 
 
 class ObjectLiteral:
     """
-    ObjectLiteral is a helper class to define object literals. Useful for
-    creating objects used as return values from a mocked API call.
+    ObjectLiteral transforms named arguments into object attributes.
+
+    This is useful for creating object literals to be used as return
+    values from mocked API calls.
 
     Source: https://stackoverflow.com/a/3335732
     """
+
     def __init__(self, **kwds):
+        """Add attributes to ourself with the provided named arguments."""
         self.__dict__.update(kwds)
 
 
 def test_constructor_default() -> None:
+    """Test that StructuredFormatter can be created without any parameters."""
     sf = StructuredFormatter()
     assert sf.component_type is None
     assert sf.component_name is None
@@ -23,6 +29,7 @@ def test_constructor_default() -> None:
 
 
 def test_constructor_supplied() -> None:
+    """Test that StructuredFormatter can be created with parameters."""
     sf = StructuredFormatter(component_type="Picker", component_name="test-picker", ndjson=False)
     assert sf.component_type == "Picker"
     assert sf.component_name == "test-picker"
@@ -31,6 +38,7 @@ def test_constructor_supplied() -> None:
 
 
 def test_format_default() -> None:
+    """Test that StructuredFormatter (no params) provides proper output."""
     sf = StructuredFormatter()
     log_record = ObjectLiteral(
         name="lta.picker",
@@ -64,6 +72,7 @@ def test_format_default() -> None:
 
 
 def test_format_supplied() -> None:
+    """Test that StructuredFormatter (with params) provides proper output."""
     sf = StructuredFormatter(component_type="Picker", component_name="test-picker", ndjson=False)
     log_record = ObjectLiteral(
         name="lta.picker",

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -1,13 +1,19 @@
 # test_square.py
+"""Module to provide a simple example of tests."""
 
+import pytest
 from lta.square import square
 
 
-def test_square() -> None:
-    assert square(-3) == 9
-    assert square(-2) == 4
-    assert square(-1) == 1
-    assert square(0) == 0
-    assert square(1) == 1
-    assert square(2) == 4
-    assert square(3) == 9
+@pytest.mark.parameterize("x, expected", [
+    pytest.param(-3, 9),
+    pytest.param(-2, 4),
+    pytest.param(-1, 1),
+    pytest.param(0, 0),
+    pytest.param(1, 1),
+    pytest.param(2, 4),
+    pytest.param(3, 9)
+])
+def test_square(x, expected) -> None:
+    """Ensure that square() returns the proper square of provided numbers."""
+    assert square(x) == expected

--- a/tests/test_square.py
+++ b/tests/test_square.py
@@ -5,7 +5,7 @@ import pytest
 from lta.square import square
 
 
-@pytest.mark.parameterize("x, expected", [
+@pytest.mark.parametrize("x, expected", [
     pytest.param(-3, 9),
     pytest.param(-2, 4),
     pytest.param(-1, 1),


### PR DESCRIPTION
Used `pip install flake8-docstrings` to add docstring linting to flake8.

Fixed up the issues that it identified, except in the rest files, so as to avoid nasty merge conflicts with files that are probably being heavily modified by David right now.
