### PR TITLE
Creates SiteMoveVerifier module

### DIFF
--- a/examples/rucio.json
+++ b/examples/rucio.json
@@ -4,12 +4,20 @@
     "password": null,
     "pfn": "gsiftp://gridftp.icecube.wisc.edu:2811/path/to/rse",
     "rest_url": "http://rucio.icecube.wisc.edu:12345",
-    "rse": "icecube-rse",
     "scope": "icecube-scope",
     "sites": {
-        "desy": "dataset-desy",
-        "nersc": "dataset-nersc",
-        "wipac": "dataset-wipac"
+        "desy": {
+            "dataset": "dataset-desy",
+            "pfn": "gsiftp://gridftp.desy.de:2811/path/to/rse"
+        },
+        "nersc": {
+            "dataset": "dataset-nersc",
+            "pfn": "gsiftp://gridftp.nersc.nim.gov:2811/path/to/rse"
+        },
+        "wipac": {
+            "dataset": "dataset-wipac",
+            "pfn": "gsiftp://gridftp.icecube.wisc.edu:2811/path/to/rse"
+        }
     },
     "username": "icecube"
 }

--- a/lta/deleter.py
+++ b/lta/deleter.py
@@ -97,7 +97,7 @@ class Deleter(Component):
     async def _delete_bundle(self, lta_rc: RestClient, bundle: BundleType) -> None:
         """Delete the provided Bundle with the transfer service and update the LTA DB."""
         bundle_id = bundle["uuid"]
-        # instantiate a TransferService to replicate the bundle
+        # instantiate a TransferService to delete the bundle
         xfer_service = instantiate(self.transfer_config)
         # ask the transfer service to cancel (i.e.: delete) the transfer
         await xfer_service.cancel(bundle["transfer_reference"])

--- a/lta/site_move_verifier.py
+++ b/lta/site_move_verifier.py
@@ -1,5 +1,5 @@
-# site_verifier.py
-"""Module to implement the SiteVerifier component of the Long Term Archive."""
+# site_move_verifier.py
+"""Module to implement the SiteMoveVerifier component of the Long Term Archive."""
 
 import asyncio
 import json
@@ -27,24 +27,25 @@ EXPECTED_CONFIG.update({
 })
 
 
-class SiteVerifier(Component):
+class SiteMoveVerifier(Component):
     """
-    SiteVerifier is a Long Term Archive component.
+    SiteMoveVerifier is a Long Term Archive component.
 
-    A SiteVerifier is responsible for verifying that a transfer to a destination
-    site has completed successfully. The transfer service is queried as to the
-    status of its work. The SiteVerifier then calculates the checksum of the
-    file to verify that the contents have been copied faithfully.
+    A SiteMoveVerifier is responsible for verifying that a transfer to a
+    destination site has completed successfully. The transfer service is
+    queried as to the status of its work. The SiteMoveVerifier then
+    calculates the checksum of the file to verify that the contents have
+    been copied faithfully.
     """
 
     def __init__(self, config: Dict[str, str], logger: Logger) -> None:
         """
-        Create a SiteVerifier component.
+        Create a SiteMoveVerifier component.
 
         config - A dictionary of required configuration values.
-        logger - The object the site_verifier should use for logging.
+        logger - The object the site_move_verifier should use for logging.
         """
-        super(SiteVerifier, self).__init__("site_verifier", config, logger)
+        super(SiteMoveVerifier, self).__init__("site_move_verifier", config, logger)
         self.next_status = config["NEXT_STATUS"]
         with open(config["TRANSFER_CONFIG_PATH"]) as config_data:
             self.transfer_config = json.load(config_data)
@@ -53,7 +54,7 @@ class SiteVerifier(Component):
         pass
 
     def _do_status(self) -> Dict[str, Any]:
-        """Provide additional status for the SiteVerifier."""
+        """Provide additional status for the SiteMoveVerifier."""
         return {}
 
     def _expected_config(self) -> Dict[str, Optional[str]]:
@@ -128,12 +129,12 @@ class SiteVerifier(Component):
 
 
 def runner() -> None:
-    """Configure a SiteVerifier component from the environment and set it running."""
+    """Configure a SiteMoveVerifier component from the environment and set it running."""
     # obtain our configuration from the environment
     config = from_environment(EXPECTED_CONFIG)
     # configure structured logging for the application
     structured_formatter = StructuredFormatter(
-        component_type='SiteVerifier',
+        component_type='SiteMoveVerifier',
         component_name=config["COMPONENT_NAME"],
         ndjson=True)
     stream_handler = logging.StreamHandler(sys.stdout)
@@ -141,18 +142,18 @@ def runner() -> None:
     root_logger = logging.getLogger(None)
     root_logger.setLevel(logging.NOTSET)
     root_logger.addHandler(stream_handler)
-    logger = logging.getLogger("lta.site_verifier")
-    # create our SiteVerifier service
-    site_verifier = SiteVerifier(config, logger)
+    logger = logging.getLogger("lta.site_move_verifier")
+    # create our SiteMoveVerifier service
+    site_move_verifier = SiteMoveVerifier(config, logger)
     # let's get to work
-    site_verifier.logger.info("Adding tasks to asyncio loop")
+    site_move_verifier.logger.info("Adding tasks to asyncio loop")
     loop = asyncio.get_event_loop()
-    loop.create_task(status_loop(site_verifier))
-    loop.create_task(work_loop(site_verifier))
+    loop.create_task(status_loop(site_move_verifier))
+    loop.create_task(work_loop(site_move_verifier))
 
 
 def main() -> None:
-    """Configure a SiteVerifier component from the environment and set it running."""
+    """Configure a SiteMoveVerifier component from the environment and set it running."""
     runner()
     asyncio.get_event_loop().run_forever()
 

--- a/lta/site_move_verifier.py
+++ b/lta/site_move_verifier.py
@@ -20,6 +20,7 @@ from .transfer.service import instantiate
 
 EXPECTED_CONFIG = COMMON_CONFIG.copy()
 EXPECTED_CONFIG.update({
+    "DEST_SITE": None,
     "NEXT_STATUS": None,
     "TRANSFER_CONFIG_PATH": "etc/rucio.json",
     "WORK_RETRIES": "3",
@@ -46,6 +47,7 @@ class SiteMoveVerifier(Component):
         logger - The object the site_move_verifier should use for logging.
         """
         super(SiteMoveVerifier, self).__init__("site_move_verifier", config, logger)
+        self.dest_site = config["DEST_SITE"]
         self.next_status = config["NEXT_STATUS"]
         with open(config["TRANSFER_CONFIG_PATH"]) as config_data:
             self.transfer_config = json.load(config_data)
@@ -81,7 +83,7 @@ class SiteMoveVerifier(Component):
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"
         }
-        response = await lta_rc.request('POST', f'/Bundles/actions/pop?source={self.source_site}&status=transferring', pop_body)
+        response = await lta_rc.request('POST', f'/Bundles/actions/pop?dest={self.dest_site}&status=transferring', pop_body)
         self.logger.info(f"LTA DB responded with: {response}")
         bundle = response["bundle"]
         if not bundle:

--- a/lta/site_verifier.py
+++ b/lta/site_verifier.py
@@ -1,0 +1,161 @@
+# site_verifier.py
+"""Module to implement the SiteVerifier component of the Long Term Archive."""
+
+import asyncio
+import json
+from logging import Logger
+import logging
+import sys
+from typing import Any, Dict, Optional
+
+from rest_tools.client import RestClient  # type: ignore
+
+from .component import COMMON_CONFIG, Component, now, status_loop, work_loop
+from .config import from_environment
+from .crypto import sha512sum
+from .log_format import StructuredFormatter
+from .lta_types import BundleType
+from .transfer.service import instantiate
+
+
+EXPECTED_CONFIG = COMMON_CONFIG.copy()
+EXPECTED_CONFIG.update({
+    "NEXT_STATUS": None,
+    "TRANSFER_CONFIG_PATH": "etc/rucio.json",
+    "WORK_RETRIES": "3",
+    "WORK_TIMEOUT_SECONDS": "30",
+})
+
+
+class SiteVerifier(Component):
+    """
+    SiteVerifier is a Long Term Archive component.
+
+    A SiteVerifier is responsible for verifying that a transfer to a destination
+    site has completed successfully. The transfer service is queried as to the
+    status of its work. The SiteVerifier then calculates the checksum of the
+    file to verify that the contents have been copied faithfully.
+    """
+
+    def __init__(self, config: Dict[str, str], logger: Logger) -> None:
+        """
+        Create a SiteVerifier component.
+
+        config - A dictionary of required configuration values.
+        logger - The object the site_verifier should use for logging.
+        """
+        super(SiteVerifier, self).__init__("site_verifier", config, logger)
+        self.next_status = config["NEXT_STATUS"]
+        with open(config["TRANSFER_CONFIG_PATH"]) as config_data:
+            self.transfer_config = json.load(config_data)
+        self.work_retries = int(config["WORK_RETRIES"])
+        self.work_timeout_seconds = float(config["WORK_TIMEOUT_SECONDS"])
+        pass
+
+    def _do_status(self) -> Dict[str, Any]:
+        """Provide additional status for the SiteVerifier."""
+        return {}
+
+    def _expected_config(self) -> Dict[str, Optional[str]]:
+        """Provide expected configuration dictionary."""
+        return EXPECTED_CONFIG
+
+    async def _do_work(self) -> None:
+        """Perform a work cycle for this component."""
+        self.logger.info("Starting work on Bundles.")
+        work_claimed = True
+        while work_claimed:
+            work_claimed = await self._do_work_claim()
+        self.logger.info("Ending work on Bundles.")
+
+    async def _do_work_claim(self) -> bool:
+        """Claim a bundle and perform work on it."""
+        # 1. Ask the LTA DB for the next Bundle to be verified
+        # configure a RestClient to talk to the LTA DB
+        lta_rc = RestClient(self.lta_rest_url,
+                            token=self.lta_rest_token,
+                            timeout=self.work_timeout_seconds,
+                            retries=self.work_retries)
+        self.logger.info("Asking the LTA DB for a Bundle to verify.")
+        pop_body = {
+            "claimant": f"{self.name}-{self.instance_uuid}"
+        }
+        response = await lta_rc.request('POST', f'/Bundles/actions/pop?source={self.source_site}&status=transferring', pop_body)
+        self.logger.info(f"LTA DB responded with: {response}")
+        bundle = response["bundle"]
+        if not bundle:
+            self.logger.info("LTA DB did not provide a Bundle to verify. Going on vacation.")
+            return False
+        # process the Bundle that we were given
+        await self._verify_bundle(lta_rc, bundle)
+        return True
+
+    async def _verify_bundle(self, lta_rc: RestClient, bundle: BundleType) -> bool:
+        """Verify the provided Bundle with the transfer service and update the LTA DB."""
+        bundle_id = bundle["uuid"]
+        # instantiate a TransferService to query about the bundle
+        xfer_service = instantiate(self.transfer_config)
+        # ask the transfer service about the status of the transfer
+        xfer_status = await xfer_service.status(bundle["transfer_reference"])
+        self.logger.info(f"Bundle transfer status is: {xfer_status}")
+        # if it's not completed, we're still waiting to verify it
+        if not xfer_status["completed"]:
+            self.logger.info(f"Transfer of Bundle {bundle_id} is incomplete and will not be verified at this time.")
+            return False
+        # we'll compute the bundle's checksum
+        bundle_path = f""  # TODO: Figure out the physical path of the bundle
+        self.logger.info(f"Computing SHA512 checksum for bundle: '{bundle_path}'")
+        checksum_sha512 = sha512sum(bundle_path)
+        self.logger.info(f"Bundle '{bundle_path}' has SHA512 checksum '{checksum_sha512}'")
+        # now we'll compare the bundle's checksum
+        if bundle["checksum"]["sha512"] != checksum_sha512:
+            self.logger.info(f"SHA512 checksum at the time of bundle creation: {bundle['checksum']['sha512']}")
+            self.logger.info(f"SHA512 checksum of the file at the destination: {checksum_sha512}")
+            self.logger.info(f"These checksums do NOT match, and the Bundle will NOT be verified.")
+            bundle["status"] = "quarantined"
+            bundle["reason"] = f"Checksum mismatch between creation and destination: {checksum_sha512}"
+            self.logger.info(f"PATCH /Bundles/{bundle_id} - '{bundle}'")
+            await lta_rc.request('PATCH', f'/Bundles/{bundle_id}', bundle)
+            return False
+        # update the Bundle in the LTA DB
+        self.logger.info(f"Destination checksum matches bundle creation checksum; the bundle is now verified.")
+        bundle["status"] = self.next_status
+        bundle["update_timestamp"] = now()
+        bundle["claimed"] = False
+        self.logger.info(f"PATCH /Bundles/{bundle_id} - '{bundle}'")
+        await lta_rc.request('PATCH', f'/Bundles/{bundle_id}', bundle)
+        return True
+
+
+def runner() -> None:
+    """Configure a SiteVerifier component from the environment and set it running."""
+    # obtain our configuration from the environment
+    config = from_environment(EXPECTED_CONFIG)
+    # configure structured logging for the application
+    structured_formatter = StructuredFormatter(
+        component_type='SiteVerifier',
+        component_name=config["COMPONENT_NAME"],
+        ndjson=True)
+    stream_handler = logging.StreamHandler(sys.stdout)
+    stream_handler.setFormatter(structured_formatter)
+    root_logger = logging.getLogger(None)
+    root_logger.setLevel(logging.NOTSET)
+    root_logger.addHandler(stream_handler)
+    logger = logging.getLogger("lta.site_verifier")
+    # create our SiteVerifier service
+    site_verifier = SiteVerifier(config, logger)
+    # let's get to work
+    site_verifier.logger.info("Adding tasks to asyncio loop")
+    loop = asyncio.get_event_loop()
+    loop.create_task(status_loop(site_verifier))
+    loop.create_task(work_loop(site_verifier))
+
+
+def main() -> None:
+    """Configure a SiteVerifier component from the environment and set it running."""
+    runner()
+    asyncio.get_event_loop().run_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/lta/transfer/rucio.py
+++ b/lta/transfer/rucio.py
@@ -200,11 +200,13 @@ class RucioTransferService(TransferService):
             "TEMPORARY_UNAVAILABLE": "PROCESSING",
         }
         our_state = STATE_MAP.get(rucio_state, "UNKNOWN")
+        # determine if the transfer is completed or not
+        completed = (our_state == "COMPLETED")
         # tell the caller what we found
         return {
             "ref": ref,
             "create_timestamp": now(),
-            "completed": True,
+            "completed": completed,
             "status": our_state,
         }
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ attrs==19.1.0
 Babel==2.7.0
 backcall==0.1.0
 binpacking==1.4.1
-certifi==2019.6.16
+certifi==2019.9.11
 chardet==3.0.4
 coverage==4.5.4
 decorator==4.4.0
@@ -16,7 +16,7 @@ flake8-polyfill==1.0.2
 future==0.17.1
 idna==2.8
 imagesize==1.1.0
-importlib-metadata==0.20
+importlib-metadata==0.22
 ipython==7.8.0
 ipython-genutils==0.2.0
 jedi==0.15.1
@@ -33,7 +33,7 @@ parso==0.5.1
 pexpect==4.7.0
 pickleshare==0.7.5
 pip==19.2.3
-pluggy==0.12.0
+pluggy==0.13.0
 prometheus-client==0.7.1
 prompt-toolkit==2.0.9
 ptyprocess==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,7 @@ flake8-polyfill==1.0.2
 future==0.17.1
 idna==2.8
 imagesize==1.1.0
-importlib-metadata==0.19
+importlib-metadata==0.20
 ipython==7.8.0
 ipython-genutils==0.2.0
 jedi==0.15.1
@@ -52,12 +52,12 @@ pytest-mock==1.10.4
 pytz==2019.2
 requests==2.22.0
 requests-futures==1.0.0
-requests-mock==1.6.0
+requests-mock==1.7.0
 requests-toolbelt==0.9.1
 -e git+https://github.com/WIPACrepo/rest-tools@3603a87fcdc98feffc22603c53e9dad113afc30a#egg=rest_tools
 setuptools==41.2.0
 six==1.12.0
-snowballstemmer==1.9.0
+snowballstemmer==1.9.1
 Sphinx==2.2.0
 sphinxcontrib-applehelp==1.0.1
 sphinxcontrib-devhelp==1.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,7 @@ more-itertools==7.2.0
 motor==2.0.0
 mypy==0.720
 mypy-extensions==0.4.1
-numpy==1.17.1
+numpy==1.17.2
 packaging==19.1
 parso==0.5.1
 pexpect==4.7.0

--- a/resources/rucio_workbench.py
+++ b/resources/rucio_workbench.py
@@ -3,7 +3,7 @@ import asyncio
 from uuid import uuid4
 
 from lta.config import from_environment
-from lta.rucio import RucioClient, RucioResponse
+from lta.transfer.rucio import RucioClient, RucioResponse
 
 EXPECTED_CONFIG = {
     "RUCIO_ACCOUNT": None,
@@ -92,32 +92,46 @@ async def main():
     # r = await rc.post(f"/dids/{scope}/{name}", did_dict)
     # print_response(r)
 
-    # show the information about the Dataset DID that we created
-    scope = "user.root"
-    name = "dataset-nersc"
-    r = await rc.get(f"/dids/{scope}/{name}")
-    print_response(r)
-
-    # attach the FILE DID to the DATASET DID within Rucio
-    scope = "user.root"
-    name = "dataset-nersc"
-    # rse = "LTA-ND-A"
-    did_dict = {
-        "dids": [
-            {
-                "scope": scope,
-                "name": "date2",
-            },
-        ],
-        # "rse": rse,
-    }
-    r = await rc.post(f"/dids/{scope}/{name}/dids", did_dict)
-    print_response(r)
+    # # show the information about the Dataset DID that we created
+    # scope = "user.root"
+    # name = "dataset-nersc"
+    # r = await rc.get(f"/dids/{scope}/{name}")
+    # print_response(r)
+    #
+    # # attach the FILE DID to the DATASET DID within Rucio
+    # scope = "user.root"
+    # name = "dataset-nersc"
+    # # rse = "LTA-ND-A"
+    # did_dict = {
+    #     "dids": [
+    #         {
+    #             "scope": scope,
+    #             "name": "date2",
+    #         },
+    #     ],
+    #     # "rse": rse,
+    # }
+    # r = await rc.post(f"/dids/{scope}/{name}/dids", did_dict)
+    # print_response(r)
 
     # check the DATASET DID to see what is attached
     scope = "user.root"
     name = "dataset-nersc"
     r = await rc.get(f"/dids/{scope}/{name}/dids")
+    print_response(r)
+
+    # List all replicas for data identifiers
+    scope = "user.root"
+    list_dict = {
+        "dids": [
+            {
+                "scope": scope,
+                "name": "0c977538-a491-4eb4-94d4-b0fc5b0f0a85.zip",
+            },
+        ],
+        "all_states": True,
+    }
+    r = await rc.post(f"/replicas/list", list_dict)
     print_response(r)
 
 

--- a/rucio-workbench.sh
+++ b/rucio-workbench.sh
@@ -4,4 +4,4 @@ export RUCIO_APP_ID=${RUCIO_APP_ID:=""}
 export RUCIO_PASSWORD=${RUCIO_PASSWORD:="hunter2"} # http://bash.org/?244321
 export RUCIO_REST_URL=${RUCIO_REST_URL:="http://rancher-worker-1:30475"}
 export RUCIO_USERNAME=${RUCIO_USERNAME:="icecube"}
-python -m resources.rucio_rest_whoami $@
+python -m resources.rucio_workbench $@

--- a/tests/test_site_move_verifier.py
+++ b/tests/test_site_move_verifier.py
@@ -1,0 +1,276 @@
+# test_site_move_verifier.py
+"""Unit tests for lta/site_move_verifier.py."""
+
+from unittest.mock import call  # MagicMock
+
+import pytest  # type: ignore
+from tornado.web import HTTPError  # type: ignore
+
+from lta.site_move_verifier import main, SiteMoveVerifier
+from .test_util import AsyncMock
+
+@pytest.fixture
+def config():
+    """Supply a stock SiteMoveVerifier component configuration."""
+    return {
+        "COMPONENT_NAME": "testing-site_move_verifier",
+        "DEST_SITE": "NERSC",
+        "HEARTBEAT_PATCH_RETRIES": "3",
+        "HEARTBEAT_PATCH_TIMEOUT_SECONDS": "30",
+        "HEARTBEAT_SLEEP_DURATION_SECONDS": "60",
+        "LTA_REST_TOKEN": "fake-lta-rest-token",
+        "LTA_REST_URL": "http://RmMNHdPhHpH2ZxfaFAC9d2jiIbf5pZiHDqy43rFLQiM.com/",
+        "NEXT_STATUS": "taping",
+        "SOURCE_SITE": "WIPAC",
+        "TRANSFER_CONFIG_PATH": "examples/rucio.json",
+        "WORK_RETRIES": "3",
+        "WORK_SLEEP_DURATION_SECONDS": "60",
+        "WORK_TIMEOUT_SECONDS": "30",
+    }
+
+def test_constructor_config(config, mocker):
+    """Test that a SiteMoveVerifier can be constructed with a configuration object and a logging object."""
+    logger_mock = mocker.MagicMock()
+    p = SiteMoveVerifier(config, logger_mock)
+    assert p.name == "testing-site_move_verifier"
+    assert p.dest_site == "NERSC"
+    assert p.heartbeat_patch_retries == 3
+    assert p.heartbeat_patch_timeout_seconds == 30
+    assert p.heartbeat_sleep_duration_seconds == 60
+    assert p.lta_rest_token == "fake-lta-rest-token"
+    assert p.lta_rest_url == "http://RmMNHdPhHpH2ZxfaFAC9d2jiIbf5pZiHDqy43rFLQiM.com/"
+    assert p.next_status == "taping"
+    assert p.source_site == "WIPAC"
+    assert p.transfer_config
+    assert p.work_retries == 3
+    assert p.work_sleep_duration_seconds == 60
+    assert p.work_timeout_seconds == 30
+    assert p.logger == logger_mock
+
+def test_do_status(config, mocker):
+    """Verify that the SiteMoveVerifier has no additional state to offer."""
+    logger_mock = mocker.MagicMock()
+    p = SiteMoveVerifier(config, logger_mock)
+    assert p._do_status() == {}
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_logs_configuration(mocker):
+    """Test to make sure the SiteMoveVerifier logs its configuration."""
+    logger_mock = mocker.MagicMock()
+    site_move_verifier_config = {
+        "COMPONENT_NAME": "logme-testing-site_move_verifier",
+        "DEST_SITE": "NERSC",
+        "HEARTBEAT_PATCH_RETRIES": "1",
+        "HEARTBEAT_PATCH_TIMEOUT_SECONDS": "20",
+        "HEARTBEAT_SLEEP_DURATION_SECONDS": "30",
+        "LTA_REST_TOKEN": "logme-fake-lta-rest-token",
+        "LTA_REST_URL": "logme-http://zjwdm5ggeEgS1tZDZy9l1DOZU53uiSO4Urmyb8xL0.com/",
+        "NEXT_STATUS": "prognosticating",
+        "SOURCE_SITE": "WIPAC",
+        "TRANSFER_CONFIG_PATH": "examples/rucio.json",
+        "WORK_RETRIES": "5",
+        "WORK_SLEEP_DURATION_SECONDS": "70",
+        "WORK_TIMEOUT_SECONDS": "90",
+    }
+    SiteMoveVerifier(site_move_verifier_config, logger_mock)
+    EXPECTED_LOGGER_CALLS = [
+        call("site_move_verifier 'logme-testing-site_move_verifier' is configured:"),
+        call('COMPONENT_NAME = logme-testing-site_move_verifier'),
+        call('DEST_SITE = NERSC'),
+        call('HEARTBEAT_PATCH_RETRIES = 1'),
+        call('HEARTBEAT_PATCH_TIMEOUT_SECONDS = 20'),
+        call('HEARTBEAT_SLEEP_DURATION_SECONDS = 30'),
+        call('LTA_REST_TOKEN = logme-fake-lta-rest-token'),
+        call('LTA_REST_URL = logme-http://zjwdm5ggeEgS1tZDZy9l1DOZU53uiSO4Urmyb8xL0.com/'),
+        call('NEXT_STATUS = prognosticating'),
+        call('SOURCE_SITE = WIPAC'),
+        call('TRANSFER_CONFIG_PATH = examples/rucio.json'),
+        call('WORK_RETRIES = 5'),
+        call('WORK_SLEEP_DURATION_SECONDS = 70'),
+        call('WORK_TIMEOUT_SECONDS = 90')
+    ]
+    logger_mock.info.assert_has_calls(EXPECTED_LOGGER_CALLS)
+
+@pytest.mark.asyncio
+async def test_script_main(config, mocker, monkeypatch):
+    """
+    Verify SiteMoveVerifier component behavior when run as a script.
+
+    Test to make sure running the SiteMoveVerifier as a script does the setup work
+    that we expect and then launches the site_move_verifier service.
+    """
+    for key in config.keys():
+        monkeypatch.setenv(key, config[key])
+    mock_event_loop = mocker.patch("asyncio.get_event_loop")
+    mock_root_logger = mocker.patch("logging.getLogger")
+    mock_status_loop = mocker.patch("lta.site_move_verifier.status_loop")
+    mock_work_loop = mocker.patch("lta.site_move_verifier.work_loop")
+    main()
+    mock_event_loop.assert_called()
+    mock_root_logger.assert_called()
+    mock_status_loop.assert_called()
+    mock_work_loop.assert_called()
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_run(config, mocker):
+    """Test the SiteMoveVerifier does the work the site_move_verifier should do."""
+    logger_mock = mocker.MagicMock()
+    p = SiteMoveVerifier(config, logger_mock)
+    p._do_work = AsyncMock()
+    await p.run()
+    p._do_work.assert_called()
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_run_exception(config, mocker):
+    """Test an error doesn't kill the SiteMoveVerifier."""
+    logger_mock = mocker.MagicMock()
+    p = SiteMoveVerifier(config, logger_mock)
+    p.last_work_end_timestamp = None
+    p._do_work = AsyncMock()
+    p._do_work.side_effect = [Exception("bad thing happen!")]
+    await p.run()
+    p._do_work.assert_called()
+    assert p.last_work_end_timestamp
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_do_work_pop_exception(config, mocker):
+    """Test that _do_work raises when the RestClient can't pop."""
+    logger_mock = mocker.MagicMock()
+    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
+    lta_rc_mock.side_effect = HTTPError(500, "LTA DB on fire. Again.")
+    p = SiteMoveVerifier(config, logger_mock)
+    with pytest.raises(HTTPError):
+        await p._do_work()
+    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?dest=NERSC&status=transferring', {'claimant': f'{p.name}-{p.instance_uuid}'})
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_do_work_no_results(config, mocker):
+    """Test that _do_work goes on vacation when the LTA DB has no work."""
+    logger_mock = mocker.MagicMock()
+    dwc_mock = mocker.patch("lta.site_move_verifier.SiteMoveVerifier._do_work_claim", new_callable=AsyncMock)
+    dwc_mock.return_value = False
+    p = SiteMoveVerifier(config, logger_mock)
+    await p._do_work()
+    dwc_mock.assert_called()
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_do_work_yes_results(config, mocker):
+    """Test that _do_work keeps working until the LTA DB has no work."""
+    logger_mock = mocker.MagicMock()
+    dwc_mock = mocker.patch("lta.site_move_verifier.SiteMoveVerifier._do_work_claim", new_callable=AsyncMock)
+    dwc_mock.side_effect = [True, True, False]
+    p = SiteMoveVerifier(config, logger_mock)
+    await p._do_work()
+    dwc_mock.assert_called()
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_do_work_claim_no_result(config, mocker):
+    """Test that _do_work_claim does not work when the LTA DB has no work."""
+    logger_mock = mocker.MagicMock()
+    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
+    lta_rc_mock.return_value = {
+        "bundle": None
+    }
+    vb_mock = mocker.patch("lta.site_move_verifier.SiteMoveVerifier._verify_bundle", new_callable=AsyncMock)
+    p = SiteMoveVerifier(config, logger_mock)
+    await p._do_work_claim()
+    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?dest=NERSC&status=transferring', {'claimant': f'{p.name}-{p.instance_uuid}'})
+    vb_mock.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_do_work_claim_yes_result(config, mocker):
+    """Test that _do_work_claim processes the Bundle that it gets from the LTA DB."""
+    logger_mock = mocker.MagicMock()
+    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
+    lta_rc_mock.return_value = {
+        "bundle": {
+            "one": 1,
+        },
+    }
+    vb_mock = mocker.patch("lta.site_move_verifier.SiteMoveVerifier._verify_bundle", new_callable=AsyncMock)
+    p = SiteMoveVerifier(config, logger_mock)
+    assert await p._do_work_claim()
+    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?dest=NERSC&status=transferring', {'claimant': f'{p.name}-{p.instance_uuid}'})
+    vb_mock.assert_called_with(mocker.ANY, {"one": 1})
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_verify_bundle_not_finished(config, mocker):
+    """Test that _delete_bundle deletes a completed bundle transfer."""
+    logger_mock = mocker.MagicMock()
+    lta_rc_mock = mocker.patch("rest_tools.client.RestClient", new_callable=AsyncMock)
+    inst_mock = mocker.patch("lta.site_move_verifier.instantiate")
+    xfer_service_mock = AsyncMock()
+    inst_mock.return_value = xfer_service_mock
+    xfer_service_mock.status.return_value = {
+        "ref": "dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip",
+        "completed": False,
+        "status": "PROCESSING",
+    }
+    bundle_obj = {
+        "uuid": "8286d3ba-fb1b-4923-876d-935bdf7fc99e",
+        "transfer_reference": "dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip",
+    }
+    p = SiteMoveVerifier(config, logger_mock)
+    await p._verify_bundle(lta_rc_mock, bundle_obj)
+    inst_mock.assert_called_with(p.transfer_config)
+    xfer_service_mock.status.assert_called_with("dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip")
+    # lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/8286d3ba-fb1b-4923-876d-935bdf7fc99e', mocker.ANY)
+    lta_rc_mock.request.assert_not_called()
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_verify_bundle_bad_checksum(config, mocker):
+    """Test that _delete_bundle deletes a completed bundle transfer."""
+    logger_mock = mocker.MagicMock()
+    lta_rc_mock = mocker.patch("rest_tools.client.RestClient", new_callable=AsyncMock)
+    inst_mock = mocker.patch("lta.site_move_verifier.instantiate")
+    xfer_service_mock = AsyncMock()
+    inst_mock.return_value = xfer_service_mock
+    xfer_service_mock.status.return_value = {
+        "ref": "dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip",
+        "completed": True,
+        "status": "COMPLETED",
+    }
+    hash_mock = mocker.patch("lta.site_move_verifier.sha512sum")
+    hash_mock.return_value = "54321"
+    bundle_obj = {
+        "uuid": "8286d3ba-fb1b-4923-876d-935bdf7fc99e",
+        "transfer_reference": "dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip",
+        "checksum": {
+            "sha512": "12345",
+        },
+    }
+    p = SiteMoveVerifier(config, logger_mock)
+    await p._verify_bundle(lta_rc_mock, bundle_obj)
+    inst_mock.assert_called_with(p.transfer_config)
+    xfer_service_mock.status.assert_called_with("dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip")
+    assert bundle_obj["status"] == "quarantined"
+    lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/8286d3ba-fb1b-4923-876d-935bdf7fc99e', mocker.ANY)
+
+@pytest.mark.asyncio
+async def test_site_move_verifier_verify_bundle_good_checksum(config, mocker):
+    """Test that _delete_bundle deletes a completed bundle transfer."""
+    logger_mock = mocker.MagicMock()
+    lta_rc_mock = mocker.patch("rest_tools.client.RestClient", new_callable=AsyncMock)
+    inst_mock = mocker.patch("lta.site_move_verifier.instantiate")
+    xfer_service_mock = AsyncMock()
+    inst_mock.return_value = xfer_service_mock
+    xfer_service_mock.status.return_value = {
+        "ref": "dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip",
+        "completed": True,
+        "status": "COMPLETED",
+    }
+    hash_mock = mocker.patch("lta.site_move_verifier.sha512sum")
+    hash_mock.return_value = "12345"
+    bundle_obj = {
+        "uuid": "8286d3ba-fb1b-4923-876d-935bdf7fc99e",
+        "transfer_reference": "dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip",
+        "checksum": {
+            "sha512": "12345",
+        },
+    }
+    p = SiteMoveVerifier(config, logger_mock)
+    await p._verify_bundle(lta_rc_mock, bundle_obj)
+    inst_mock.assert_called_with(p.transfer_config)
+    xfer_service_mock.status.assert_called_with("dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip")
+    assert bundle_obj["status"] == "taping"
+    lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/8286d3ba-fb1b-4923-876d-935bdf7fc99e', mocker.ANY)

--- a/tests/test_site_move_verifier.py
+++ b/tests/test_site_move_verifier.py
@@ -234,7 +234,10 @@ async def test_site_move_verifier_verify_bundle_bad_checksum(config, mocker):
     hash_mock.return_value = "54321"
     bundle_obj = {
         "uuid": "8286d3ba-fb1b-4923-876d-935bdf7fc99e",
+        "dest": "nersc",
+        "path": "/data/exp/IceCube/2014/unbiased/PFRaw/1109",
         "transfer_reference": "dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip",
+        "bundle_path": "/mnt/lfss/lta/scratch/8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip",
         "checksum": {
             "sha512": "12345",
         },
@@ -243,6 +246,7 @@ async def test_site_move_verifier_verify_bundle_bad_checksum(config, mocker):
     await p._verify_bundle(lta_rc_mock, bundle_obj)
     inst_mock.assert_called_with(p.transfer_config)
     xfer_service_mock.status.assert_called_with("dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip")
+    hash_mock.assert_called_with("/path/to/rse/8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip")
     assert bundle_obj["status"] == "quarantined"
     lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/8286d3ba-fb1b-4923-876d-935bdf7fc99e', mocker.ANY)
 
@@ -263,7 +267,10 @@ async def test_site_move_verifier_verify_bundle_good_checksum(config, mocker):
     hash_mock.return_value = "12345"
     bundle_obj = {
         "uuid": "8286d3ba-fb1b-4923-876d-935bdf7fc99e",
+        "dest": "nersc",
+        "path": "/data/exp/IceCube/2014/unbiased/PFRaw/1109",
         "transfer_reference": "dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip",
+        "bundle_path": "/mnt/lfss/lta/scratch/8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip",
         "checksum": {
             "sha512": "12345",
         },
@@ -272,5 +279,6 @@ async def test_site_move_verifier_verify_bundle_good_checksum(config, mocker):
     await p._verify_bundle(lta_rc_mock, bundle_obj)
     inst_mock.assert_called_with(p.transfer_config)
     xfer_service_mock.status.assert_called_with("dataset-nersc|8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip")
+    hash_mock.assert_called_with("/path/to/rse/8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip")
     assert bundle_obj["status"] == "taping"
     lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/8286d3ba-fb1b-4923-876d-935bdf7fc99e', mocker.ANY)


### PR DESCRIPTION
First draft at the core logic of the component. A few points:
- `NEXT_STATUS` is a configuration variable that depends on the site. For NERSC this status will be `taping` (i.e.: next step is to issue an hpss command to move it to tape). For DESY this status will be `verifying` (i.e.: next step is to copy the file to its final destination and verify the final destination checksum)
- A checksum mismatch causes the Bundle to be quarantined. If Rucio thinks it finished transferring the file, but the sha512 checksum doesn't match, this is operator intervention territory.

Work still to be done:
- [x] ~Unit tests still need to be written for the SiteMoveVerifier~
- [x] ~`SiteMoveVerifier._verify_bundle()` has a `TODO` about computing the physical path name of the bundle at the destination site. Vlad helped Patrick decipher the Rucio RSE voodoo, but some changes are needed to the RucioTransferService configuration (per-site specification of the `pfn` (physical file name) prefix used at that RSE)~
- [x] ~`RucioTransferService.status()` is still a stub and needs to be implemented~
- [ ] Integration tests still be to be performed by sitting with Vlad and making Rucio jump through its hoops

Ready for initial review.