### PR TITLE
Improve quarantine bundle reason messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 - in case of vulnerabilities
 
+## [0.17.0] - 2020-08-25
+### Changed
+- Format of quarantine reason messages for Bundles
+
 ## [0.16.0] - 2020-08-18
 ### Added
 - Added NerscRetriever component for reading bundle files from HPSS at NERSC

--- a/lta/__init__.py
+++ b/lta/__init__.py
@@ -9,5 +9,5 @@ from __future__ import absolute_import, division, print_function
 # is zero for an official release, positive for a development branch,
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
-__version__ = '0.16.0'
-version_info = (0, 16, 0, 0)
+__version__ = '0.17.0'
+version_info = (0, 17, 0, 0)

--- a/lta/deleter.py
+++ b/lta/deleter.py
@@ -109,6 +109,7 @@ class Deleter(Component):
         self.logger.info(f"File {bundle_path} was deleted from the disk.")
         patch_body = {
             "status": self.output_status,
+            "reason": "",
             "update_timestamp": now(),
             "claimed": False,
         }
@@ -125,7 +126,7 @@ class Deleter(Component):
         right_now = now()
         patch_body = {
             "status": "quarantined",
-            "reason": reason,
+            "reason": f"BY:{self.name}-{self.instance_uuid} REASON:{reason}",
             "work_priority_timestamp": right_now,
         }
         try:

--- a/lta/locator.py
+++ b/lta/locator.py
@@ -184,6 +184,7 @@ class Locator(Component):
                 "type": "Bundle",
                 # "uuid": unique_id(),  # provided by LTA DB
                 "status": "located",
+                "reason": "",
                 # "create_timestamp": right_now,  # provided by LTA DB
                 # "update_timestamp": right_now,  # provided by LTA DB
                 "request": tr["uuid"],
@@ -242,7 +243,7 @@ class Locator(Component):
         right_now = now()
         patch_body = {
             "status": "quarantined",
-            "reason": reason,
+            "reason": f"BY:{self.name}-{self.instance_uuid} REASON:{reason}",
             "work_priority_timestamp": right_now,
         }
         try:

--- a/lta/nersc_mover.py
+++ b/lta/nersc_mover.py
@@ -113,7 +113,7 @@ class NerscMover(Component):
             right_now = now()
             patch_body = {
                 "status": "quarantined",
-                "reason": f"Exception during execution: {e}",
+                "reason": f"BY:{self.name}-{self.instance_uuid} REASON:Exception during execution: {e}",
                 "work_priority_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")
@@ -150,6 +150,7 @@ class NerscMover(Component):
         # otherwise, update the Bundle in the LTA DB
         patch_body = {
             "status": "verifying",
+            "reason": "",
             "update_timestamp": now(),
             "claimed": False,
         }
@@ -169,7 +170,7 @@ class NerscMover(Component):
             right_now = now()
             patch_body = {
                 "status": "quarantined",
-                "reason": "hsi Command Failed",
+                "reason": f"BY:{self.name}-{self.instance_uuid} REASON:hsi Command Failed - {completed_process.args} - {completed_process.returncode} - {str(completed_process.stdout)} - {str(completed_process.stderr)}",
                 "work_priority_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")

--- a/lta/nersc_retriever.py
+++ b/lta/nersc_retriever.py
@@ -113,7 +113,7 @@ class NerscRetriever(Component):
             right_now = now()
             patch_body = {
                 "status": "quarantined",
-                "reason": f"Exception during execution: {e}",
+                "reason": f"BY:{self.name}-{self.instance_uuid} REASON:Exception during execution: {e}",
                 "work_priority_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")
@@ -142,6 +142,7 @@ class NerscRetriever(Component):
         # update the Bundle in the LTA DB
         patch_body = {
             "status": "staged",
+            "reason": "",
             "update_timestamp": now(),
             "claimed": False,
         }
@@ -161,7 +162,7 @@ class NerscRetriever(Component):
             right_now = now()
             patch_body = {
                 "status": "quarantined",
-                "reason": "hsi Command Failed",
+                "reason": f"BY:{self.name}-{self.instance_uuid} REASON:hsi Command Failed - {completed_process.args} - {completed_process.returncode} - {str(completed_process.stdout)} - {str(completed_process.stderr)}",
                 "work_priority_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")

--- a/lta/nersc_verifier.py
+++ b/lta/nersc_verifier.py
@@ -123,7 +123,7 @@ class NerscVerifier(Component):
             right_now = now()
             patch_body = {
                 "status": "quarantined",
-                "reason": f"Exception during execution: {e}",
+                "reason": f"BY:{self.name}-{self.instance_uuid} REASON:Exception during execution: {e}",
                 "work_priority_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")
@@ -196,6 +196,7 @@ class NerscVerifier(Component):
         bundle_id = bundle["uuid"]
         patch_body = {
             "status": "completed",
+            "reason": "",
             "update_timestamp": now(),
             "claimed": False,
         }
@@ -232,7 +233,7 @@ class NerscVerifier(Component):
             right_now = now()
             patch_body = {
                 "status": "quarantined",
-                "reason": "hsi hashlist Command Failed",
+                "reason": f"BY:{self.name}-{self.instance_uuid} REASON:hsi hashlist Command Failed",
                 "work_priority_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")
@@ -253,7 +254,7 @@ class NerscVerifier(Component):
             right_now = now()
             patch_body = {
                 "status": "quarantined",
-                "reason": f"Checksum mismatch between creation and destination: {checksum_sha512}",
+                "reason": f"BY:{self.name}-{self.instance_uuid} REASON:Checksum mismatch between creation and destination: {checksum_sha512}",
                 "work_priority_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")
@@ -280,7 +281,7 @@ class NerscVerifier(Component):
             right_now = now()
             patch_body = {
                 "status": "quarantined",
-                "reason": "hsi hashverify Command Failed",
+                "reason": f"BY:{self.name}-{self.instance_uuid} REASON:hsi hashverify Command Failed",
                 "work_priority_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")
@@ -305,7 +306,7 @@ class NerscVerifier(Component):
             right_now = now()
             patch_body = {
                 "status": "quarantined",
-                "reason": f"hashverify unable to verify checksum in HPSS: {result}",
+                "reason": f"BY:{self.name}-{self.instance_uuid} REASON:hashverify unable to verify checksum in HPSS: {result}",
                 "work_priority_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")

--- a/lta/picker.py
+++ b/lta/picker.py
@@ -179,6 +179,7 @@ class Picker(Component):
                 "type": "Bundle",
                 # "uuid": unique_id(),  # provided by LTA DB
                 "status": "specified",
+                "reason": "",
                 # "create_timestamp": right_now,  # provided by LTA DB
                 # "update_timestamp": right_now,  # provided by LTA DB
                 "request": tr["uuid"],
@@ -207,7 +208,7 @@ class Picker(Component):
         right_now = now()
         patch_body = {
             "status": "quarantined",
-            "reason": reason,
+            "reason": f"BY:{self.name}-{self.instance_uuid} REASON:{reason}",
             "work_priority_timestamp": right_now,
         }
         try:

--- a/lta/replicator.py
+++ b/lta/replicator.py
@@ -108,7 +108,7 @@ class Replicator(Component):
         right_now = now()
         patch_body = {
             "status": "quarantined",
-            "reason": reason,
+            "reason": f"BY:{self.name}-{self.instance_uuid} REASON:{reason}",
             "work_priority_timestamp": right_now,
         }
         try:
@@ -126,6 +126,7 @@ class Replicator(Component):
         # update the Bundle in the LTA DB
         patch_body = {
             "status": "transferring",
+            "reason": "",
             "update_timestamp": now(),
             "claimed": False,
             "transfer_reference": xfer_ref,

--- a/lta/rucio_stager.py
+++ b/lta/rucio_stager.py
@@ -126,7 +126,7 @@ class RucioStager(Component):
         right_now = now()
         patch_body = {
             "status": "quarantined",
-            "reason": reason,
+            "reason": f"BY:{self.name}-{self.instance_uuid} REASON:{reason}",
             "work_priority_timestamp": right_now,
         }
         try:
@@ -165,6 +165,7 @@ class RucioStager(Component):
             "bundle_path": dst_path,
             "claimed": False,
             "status": "staged",
+            "reason": "",
             "update_timestamp": now(),
         }
         self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")

--- a/lta/site_move_verifier.py
+++ b/lta/site_move_verifier.py
@@ -145,7 +145,7 @@ class SiteMoveVerifier(Component):
         right_now = now()
         patch_body = {
             "status": "quarantined",
-            "reason": reason,
+            "reason": f"BY:{self.name}-{self.instance_uuid} REASON:{reason}",
             "work_priority_timestamp": right_now,
         }
         try:
@@ -198,7 +198,7 @@ class SiteMoveVerifier(Component):
             right_now = now()
             patch_body: Dict[str, Any] = {
                 "status": "quarantined",
-                "reason": f"Checksum mismatch between creation and destination: {checksum_sha512}",
+                "reason": f"BY:{self.name}-{self.instance_uuid} REASON:Checksum mismatch between creation and destination: {checksum_sha512}",
                 "work_priority_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")
@@ -208,6 +208,7 @@ class SiteMoveVerifier(Component):
         self.logger.info("Destination checksum matches bundle creation checksum; the bundle is now verified.")
         patch_body = {
             "status": self.next_status,
+            "reason": "",
             "update_timestamp": now(),
             "claimed": False,
         }

--- a/lta/transfer_request_finisher.py
+++ b/lta/transfer_request_finisher.py
@@ -130,6 +130,7 @@ class TransferRequestFinisher(Component):
             "claimed": False,
             "claim_timestamp": right_now,
             "status": "completed",
+            "reason": "",
             "update_timestamp": right_now,
         }
         self.logger.info(f"PATCH /TransferRequests/{request_uuid} - '{patch_body}'")
@@ -141,6 +142,7 @@ class TransferRequestFinisher(Component):
                 "claimed": False,
                 "claim_timestamp": right_now,
                 "status": "finished",
+                "reason": "",
                 "update_timestamp": right_now,
             }
             self.logger.info(f"PATCH /Bundles/{bundle_id} - '{patch_body}'")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 alabaster==0.7.12
 asn1crypto==1.4.0
 atomicwrites==1.4.0
-attrs==19.3.0
+attrs==20.1.0
 Babel==2.8.0
 backcall==0.2.0
 binpacking==1.4.3
@@ -34,7 +34,7 @@ mypy==0.782
 mypy-extensions==0.4.3
 numpy==1.19.1
 packaging==20.4
-parso==0.8.0
+parso==0.7.1
 pexpect==4.8.0
 pickleshare==0.7.5
 pip==20.2.2
@@ -45,7 +45,7 @@ ptyprocess==0.6.0
 py==1.9.0
 pycodestyle==2.6.0
 pycparser==2.20
-pydocstyle==5.0.2
+pydocstyle==5.1.0
 pyflakes==2.2.0
 Pygments==2.6.1
 PyJWT==1.7.1
@@ -55,7 +55,7 @@ pyparsing==2.4.7
 pytest==6.0.1
 pytest-asyncio==0.14.0
 pytest-cov==2.10.1
-pytest-mock==3.2.0
+pytest-mock==3.3.0
 python-dateutil==2.8.1
 pytz==2020.1
 requests==2.24.0
@@ -77,7 +77,7 @@ sphinxcontrib-websupport==1.2.4
 tornado==6.0.4
 traitlets==4.3.3
 typed-ast==1.4.1
-typing-extensions==3.7.4.2
+typing-extensions==3.7.4.3
 urllib3==1.25.10
 wcwidth==0.2.5
 wheel==0.35.1

--- a/tests/test_locator.py
+++ b/tests/test_locator.py
@@ -301,7 +301,7 @@ async def test_locator_do_work_transfer_request_fc_exception(config, mocker):
 @pytest.mark.asyncio
 async def test_locator_do_work_transfer_request_fc_no_results(config, mocker):
     """Test that _do_work_transfer_request raises an exception when the LTA DB refuses to create an empty list."""
-    QUARANTINE = {'status': 'quarantined', 'reason': 'File Catalog returned zero files for the TransferRequest', 'work_priority_timestamp': mocker.ANY}
+    QUARANTINE = {'status': 'quarantined', 'reason': mocker.ANY, 'work_priority_timestamp': mocker.ANY}
     logger_mock = mocker.MagicMock()
     p = Locator(config, logger_mock)
     lta_rc_mock = mocker.MagicMock()
@@ -432,6 +432,7 @@ async def test_locator_do_work_transfer_request_fc_yes_results(config, mocker):
     cb_mock.assert_called_with(lta_rc_mock, {
         'type': 'Bundle',
         'status': 'located',
+        'reason': '',
         'request': tr_uuid,
         'source': 'nersc',
         'dest': 'wipac',
@@ -552,6 +553,7 @@ async def test_locator_do_work_transfer_request_fc_its_over_9000(config, mocker)
     cb_mock.assert_called_with(lta_rc_mock, {
         'type': 'Bundle',
         'status': 'located',
+        'reason': '',
         'request': tr_uuid,
         'source': 'nersc',
         'dest': 'wipac',

--- a/tests/test_picker.py
+++ b/tests/test_picker.py
@@ -280,7 +280,7 @@ async def test_picker_do_work_transfer_request_fc_exception(config, mocker):
 @pytest.mark.asyncio
 async def test_picker_do_work_transfer_request_fc_no_results(config, mocker):
     """Test that _do_work_transfer_request raises an exception when the LTA DB refuses to create an empty list."""
-    QUARANTINE = {'status': 'quarantined', 'reason': 'File Catalog returned zero files for the TransferRequest', 'work_priority_timestamp': mocker.ANY}
+    QUARANTINE = {'status': 'quarantined', 'reason': mocker.ANY, 'work_priority_timestamp': mocker.ANY}
     logger_mock = mocker.MagicMock()
     p = Picker(config, logger_mock)
     lta_rc_mock = mocker.MagicMock()

--- a/tests/test_site_move_verifier.py
+++ b/tests/test_site_move_verifier.py
@@ -412,6 +412,7 @@ async def test_site_move_verifier_verify_bundle_good_checksum(config, mocker):
     hash_mock.assert_called_with("/path/to/rse/8286d3ba-fb1b-4923-876d-935bdf7fc99e.zip")
     lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/8286d3ba-fb1b-4923-876d-935bdf7fc99e', {
         "status": "taping",
+        "reason": "",
         "update_timestamp": mocker.ANY,
         "claimed": False,
     })

--- a/tests/test_transfer_request_finisher.py
+++ b/tests/test_transfer_request_finisher.py
@@ -262,5 +262,6 @@ async def test_transfer_request_finisher_update_transfer_request_yes(config, moc
         "claimed": False,
         "claim_timestamp": mocker.ANY,
         "status": "finished",
+        "reason": "",
         "update_timestamp": mocker.ANY,
     })


### PR DESCRIPTION
* When components quarantine a bundle, they now add their identification (component name and UUID) to the reason message
* Quarantine reason messaging improved in several components, especially those interacting with HPSS
* When components successfully process a bundle, they remove (set to `""`) any old quarantine reason message
* A few components had `_quarantine_bundle` handlers added to them
