### PR TITLE
Fix Unpacker location update in File Catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 - in case of vulnerabilities
 
+## [0.26.0] - 2020-10-30
+### Fixed
+- Unpacker specifies the correct file and path to update in the File Catalog
+
 ## [0.25.0] - 2020-10-29
 ### Fixed
 - Unpacker uses the correct field in the bundle to compute paths

--- a/lta/__init__.py
+++ b/lta/__init__.py
@@ -9,5 +9,5 @@ from __future__ import absolute_import, division, print_function
 # is zero for an official release, positive for a development branch,
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
-__version__ = '0.25.0'
-version_info = (0, 25, 0, 0)
+__version__ = '0.26.0'
+version_info = (0, 26, 0, 0)

--- a/tests/test_unpacker.py
+++ b/tests/test_unpacker.py
@@ -318,9 +318,24 @@ async def test_unpacker_add_location_to_file_catalog(config, mocker):
     logger_mock = mocker.MagicMock()
     fc_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
     p = Unpacker(config, logger_mock)
-    assert await p._add_location_to_file_catalog("c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003", "/path/in/the/data/warehouse.tar.bz2")
-    fc_rc_mock.assert_called_with("POST", "/api/files/c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003/locations", mocker.ANY)
-
+    bundle_file = {
+        "checksum": {
+            "sha512": "09de7c539b724dee9543669309f978b172f6c7449d0269fecbb57d0c9cf7db51713fed3a94573c669fe0aa08fa122b41f84a0ea107c62f514b1525efbd08846b",
+        },
+        "file_size": 105311728,
+        "logical_name": "/data/exp/IceCube/2013/filtered/PFFilt/1109/PFFilt_PhysicsFiltering_Run00123231_Subrun00000000_00000066.tar.bz2",
+        "meta_modify_date": "2020-02-20 22:47:25.180303",
+        "uuid": "2f0cb3c8-6cba-49b1-8eeb-13e13fed41dd",
+    }
+    assert await p._add_location_to_file_catalog(bundle_file)
+    fc_rc_mock.assert_called_with("POST", "/api/files/2f0cb3c8-6cba-49b1-8eeb-13e13fed41dd/locations", {
+        "locations": [
+            {
+                "site": "WIPAC",
+                "path": "/data/exp/IceCube/2013/filtered/PFFilt/1109/PFFilt_PhysicsFiltering_Run00123231_Subrun00000000_00000066.tar.bz2",
+            }
+        ]
+    })
 
 @pytest.mark.asyncio
 async def test_unpacker_do_work_bundle(config, mocker):


### PR DESCRIPTION
When the Unpacker is unpacking files, update the correct file with the correct location in the File Catalog.
