### PR TITLE
Retool RucioStager as RateLimiter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Security
 - in case of vulnerabilities
 
-## [0.38.0] - 2021-02-16
+## [0.39.0] - 2021-02-18
+### Changed
+- RucioStager has been renamed RateLimiter
+
+## [0.38.0] - 2021-02-18
 ### Fixed
 - DesyVerifier component now populates the File Catalog from verified bundles
 - DesyVerifier and NerscVerifier stop recording constituent files in the File Catalog record of the bundle

--- a/bin/rate-limiter.sh
+++ b/bin/rate-limiter.sh
@@ -1,20 +1,19 @@
 #!/usr/bin/env bash
-export BUNDLER_OUTBOX_PATH=${BUNDLER_OUTBOX_PATH:="/mnt/lfss/jade-lta/bundler_stage"}
-export DEST_SITE=${DEST_SITE:="NERSC"}
-export COMPONENT_NAME=${COMPONENT_NAME:="$(hostname)-rucio-stager"}
-export DEST_QUOTA=${DEST_QUOTA:="12094627905536"}  # 11 TiB
+export COMPONENT_NAME=${COMPONENT_NAME:="$(hostname)-rate-limiter"}
 export DEST_SITE=${DEST_SITE:="NERSC"}
 export HEARTBEAT_PATCH_RETRIES=${HEARTBEAT_PATCH_RETRIES:="3"}
 export HEARTBEAT_PATCH_TIMEOUT_SECONDS=${HEARTBEAT_PATCH_TIMEOUT_SECONDS:="5"}
 export HEARTBEAT_SLEEP_DURATION_SECONDS=${HEARTBEAT_SLEEP_DURATION_SECONDS:="30"}
+export INPUT_PATH=${INPUT_PATH:="/mnt/lfss/jade-lta/bundler_stage"}
 export INPUT_STATUS=${INPUT_STATUS:="created"}
 export LTA_REST_TOKEN=${LTA_REST_TOKEN:="$(resources/solicit-token.sh)"}
 export LTA_REST_URL=${LTA_REST_URL:="http://127.0.0.1:8080"}
+export OUTPUT_PATH=${OUTPUT_PATH:="/mnt/lfss/jade-lta/bundler_out"}
+export OUTPUT_QUOTA=${OUTPUT_QUOTA:="12094627905536"}  # 11 TiB
 export OUTPUT_STATUS=${OUTPUT_STATUS:="staged"}
-export RUCIO_INBOX_PATH=${RUCIO_INBOX_PATH:="/mnt/lfss/jade-lta/bundler_out"}
 export RUN_ONCE_AND_DIE=${RUN_ONCE_AND_DIE:="False"}
 export SOURCE_SITE=${SOURCE_SITE:="WIPAC"}
 export WORK_RETRIES=${WORK_RETRIES:="3"}
-export WORK_SLEEP_DURATION_SECONDS=${WORK_SLEEP_DURATION_SECONDS:="30"}
+export WORK_SLEEP_DURATION_SECONDS=${WORK_SLEEP_DURATION_SECONDS:="60"}
 export WORK_TIMEOUT_SECONDS=${WORK_TIMEOUT_SECONDS:="5"}
-python -m lta.rucio_stager
+python -m lta.rate_limiter

--- a/lta/__init__.py
+++ b/lta/__init__.py
@@ -9,5 +9,5 @@ from __future__ import absolute_import, division, print_function
 # is zero for an official release, positive for a development branch,
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
-__version__ = '0.38.0'
-version_info = (0, 38, 0, 0)
+__version__ = '0.39.0'
+version_info = (0, 39, 0, 0)

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,30 +1,30 @@
-# test_rucio_stager.py
-"""Unit tests for lta/rucio_stager.py."""
+# test_rate_limiter.py
+"""Unit tests for lta/rate_limiter.py."""
 
 from unittest.mock import call, MagicMock
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
-from lta.rucio_stager import main, RucioStager
+from lta.rate_limiter import main, RateLimiter
 from .test_util import AsyncMock
 
 @pytest.fixture
 def config():
-    """Supply a stock RucioStager component configuration."""
+    """Supply a stock RateLimiter component configuration."""
     return {
-        "BUNDLER_OUTBOX_PATH": "/path/to/icecube/bundler/outbox",
-        "COMPONENT_NAME": "testing-rucio_stager",
-        "DEST_QUOTA": "12094627905536",  # 11 TiB
+        "COMPONENT_NAME": "testing-rate_limiter",
         "DEST_SITE": "NERSC",
         "HEARTBEAT_PATCH_RETRIES": "3",
         "HEARTBEAT_PATCH_TIMEOUT_SECONDS": "30",
         "HEARTBEAT_SLEEP_DURATION_SECONDS": "60",
+        "INPUT_PATH": "/path/to/icecube/bundler/outbox",
         "INPUT_STATUS": "created",
         "LTA_REST_TOKEN": "fake-lta-rest-token",
         "LTA_REST_URL": "http://RmMNHdPhHpH2ZxfaFAC9d2jiIbf5pZiHDqy43rFLQiM.com/",
+        "OUTPUT_PATH": "/path/to/icecube/replicator/inbox",
+        "OUTPUT_QUOTA": "12094627905536",  # 11 TiB
         "OUTPUT_STATUS": "staged",
-        "RUCIO_INBOX_PATH": "/path/to/icecube/rucio/inbox",
         "RUN_ONCE_AND_DIE": "False",
         "SOURCE_SITE": "WIPAC",
         "WORK_RETRIES": "3",
@@ -33,19 +33,21 @@ def config():
     }
 
 def test_constructor_config(config, mocker):
-    """Test that a RucioStager can be constructed with a configuration object and a logging object."""
+    """Test that a RateLimiter can be constructed with a configuration object and a logging object."""
     logger_mock = mocker.MagicMock()
-    p = RucioStager(config, logger_mock)
-    assert p.name == "testing-rucio_stager"
-    assert p.bundler_outbox_path == "/path/to/icecube/bundler/outbox"
-    assert p.dest_quota == 12094627905536
+    p = RateLimiter(config, logger_mock)
+    assert p.name == "testing-rate_limiter"
     assert p.dest_site == "NERSC"
     assert p.heartbeat_patch_retries == 3
     assert p.heartbeat_patch_timeout_seconds == 30
     assert p.heartbeat_sleep_duration_seconds == 60
+    assert p.input_path == "/path/to/icecube/bundler/outbox"
+    assert p.input_status == "created"
     assert p.lta_rest_token == "fake-lta-rest-token"
     assert p.lta_rest_url == "http://RmMNHdPhHpH2ZxfaFAC9d2jiIbf5pZiHDqy43rFLQiM.com/"
-    assert p.rucio_inbox_path == "/path/to/icecube/rucio/inbox"
+    assert p.output_path == "/path/to/icecube/replicator/inbox"
+    assert p.output_quota == 12094627905536
+    assert p.output_status == "staged"
     assert not p.run_once_and_die
     assert p.source_site == "WIPAC"
     assert p.work_retries == 3
@@ -55,49 +57,49 @@ def test_constructor_config(config, mocker):
 
 
 def test_do_status(config, mocker):
-    """Verify that the RucioStager has no additional state to offer."""
+    """Verify that the RateLimiter has no additional state to offer."""
     logger_mock = mocker.MagicMock()
-    p = RucioStager(config, logger_mock)
+    p = RateLimiter(config, logger_mock)
     assert p._do_status() == {}
 
 @pytest.mark.asyncio
-async def test_rucio_stager_logs_configuration(mocker):
-    """Test to make sure the RucioStager logs its configuration."""
+async def test_rate_limiter_logs_configuration(mocker):
+    """Test to make sure the RateLimiter logs its configuration."""
     logger_mock = mocker.MagicMock()
-    rucio_stager_config = {
-        "BUNDLER_OUTBOX_PATH": "/path/to/icecube/bundler/outbox",
-        "COMPONENT_NAME": "logme-testing-rucio_stager",
-        "DEST_QUOTA": "12094627905536",  # 11 TiB
+    rate_limiter_config = {
+        "COMPONENT_NAME": "logme-testing-rate_limiter",
         "DEST_SITE": "NERSC",
         "HEARTBEAT_PATCH_RETRIES": "1",
         "HEARTBEAT_PATCH_TIMEOUT_SECONDS": "20",
         "HEARTBEAT_SLEEP_DURATION_SECONDS": "30",
+        "INPUT_PATH": "/path/to/icecube/bundler/outbox",
         "INPUT_STATUS": "created",
         "LTA_REST_TOKEN": "logme-fake-lta-rest-token",
         "LTA_REST_URL": "logme-http://zjwdm5ggeEgS1tZDZy9l1DOZU53uiSO4Urmyb8xL0.com/",
+        "OUTPUT_PATH": "/path/to/icecube/replicator/inbox",
+        "OUTPUT_QUOTA": "12094627905536",  # 11 TiB
         "OUTPUT_STATUS": "staged",
-        "RUCIO_INBOX_PATH": "/path/to/icecube/rucio/inbox",
         "RUN_ONCE_AND_DIE": "False",
         "SOURCE_SITE": "WIPAC",
         "WORK_RETRIES": "5",
         "WORK_SLEEP_DURATION_SECONDS": "70",
         "WORK_TIMEOUT_SECONDS": "90",
     }
-    RucioStager(rucio_stager_config, logger_mock)
+    RateLimiter(rate_limiter_config, logger_mock)
     EXPECTED_LOGGER_CALLS = [
-        call("rucio_stager 'logme-testing-rucio_stager' is configured:"),
-        call('BUNDLER_OUTBOX_PATH = /path/to/icecube/bundler/outbox'),
-        call('COMPONENT_NAME = logme-testing-rucio_stager'),
-        call('DEST_QUOTA = 12094627905536'),
+        call("rate_limiter 'logme-testing-rate_limiter' is configured:"),
+        call('COMPONENT_NAME = logme-testing-rate_limiter'),
         call('DEST_SITE = NERSC'),
         call('HEARTBEAT_PATCH_RETRIES = 1'),
         call('HEARTBEAT_PATCH_TIMEOUT_SECONDS = 20'),
         call('HEARTBEAT_SLEEP_DURATION_SECONDS = 30'),
+        call('INPUT_PATH = /path/to/icecube/bundler/outbox'),
         call('INPUT_STATUS = created'),
         call('LTA_REST_TOKEN = logme-fake-lta-rest-token'),
         call('LTA_REST_URL = logme-http://zjwdm5ggeEgS1tZDZy9l1DOZU53uiSO4Urmyb8xL0.com/'),
+        call('OUTPUT_PATH = /path/to/icecube/replicator/inbox'),
+        call('OUTPUT_QUOTA = 12094627905536'),
         call('OUTPUT_STATUS = staged'),
-        call('RUCIO_INBOX_PATH = /path/to/icecube/rucio/inbox'),
         call('RUN_ONCE_AND_DIE = False'),
         call('SOURCE_SITE = WIPAC'),
         call('WORK_RETRIES = 5'),
@@ -109,17 +111,17 @@ async def test_rucio_stager_logs_configuration(mocker):
 @pytest.mark.asyncio
 async def test_script_main(config, mocker, monkeypatch):
     """
-    Verify RucioStager component behavior when run as a script.
+    Verify RateLimiter component behavior when run as a script.
 
-    Test to make sure running the RucioStager as a script does the setup work
-    that we expect and then launches the rucio_stager service.
+    Test to make sure running the RateLimiter as a script does the setup work
+    that we expect and then launches the rate_limiter service.
     """
     for key in config.keys():
         monkeypatch.setenv(key, config[key])
     mock_event_loop = mocker.patch("asyncio.get_event_loop")
     mock_root_logger = mocker.patch("logging.getLogger")
-    mock_status_loop = mocker.patch("lta.rucio_stager.status_loop")
-    mock_work_loop = mocker.patch("lta.rucio_stager.work_loop")
+    mock_status_loop = mocker.patch("lta.rate_limiter.status_loop")
+    mock_work_loop = mocker.patch("lta.rate_limiter.work_loop")
     main()
     mock_event_loop.assert_called()
     mock_root_logger.assert_called()
@@ -127,19 +129,19 @@ async def test_script_main(config, mocker, monkeypatch):
     mock_work_loop.assert_called()
 
 @pytest.mark.asyncio
-async def test_rucio_stager_run(config, mocker):
-    """Test the RucioStager does the work the rucio_stager should do."""
+async def test_rate_limiter_run(config, mocker):
+    """Test the RateLimiter does the work the rate_limiter should do."""
     logger_mock = mocker.MagicMock()
-    p = RucioStager(config, logger_mock)
+    p = RateLimiter(config, logger_mock)
     p._do_work = AsyncMock()
     await p.run()
     p._do_work.assert_called()
 
 @pytest.mark.asyncio
-async def test_rucio_stager_run_exception(config, mocker):
-    """Test an error doesn't kill the RucioStager."""
+async def test_rate_limiter_run_exception(config, mocker):
+    """Test an error doesn't kill the RateLimiter."""
     logger_mock = mocker.MagicMock()
-    p = RucioStager(config, logger_mock)
+    p = RateLimiter(config, logger_mock)
     p.last_work_end_timestamp = None
     p._do_work = AsyncMock()
     p._do_work.side_effect = [Exception("bad thing happen!")]
@@ -148,52 +150,52 @@ async def test_rucio_stager_run_exception(config, mocker):
     assert p.last_work_end_timestamp
 
 @pytest.mark.asyncio
-async def test_rucio_stager_do_work_pop_exception(config, mocker):
+async def test_rate_limiter_do_work_pop_exception(config, mocker):
     """Test that _do_work raises when the RestClient can't pop."""
     logger_mock = mocker.MagicMock()
     lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
     lta_rc_mock.side_effect = HTTPError(500, "LTA DB on fire. Again.")
-    p = RucioStager(config, logger_mock)
+    p = RateLimiter(config, logger_mock)
     with pytest.raises(HTTPError):
         await p._do_work()
     lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=NERSC&status=created', {'claimant': f'{p.name}-{p.instance_uuid}'})
 
 @pytest.mark.asyncio
-async def test_rucio_stager_do_work_no_results(config, mocker):
+async def test_rate_limiter_do_work_no_results(config, mocker):
     """Test that _do_work goes on vacation when the LTA DB has no work."""
     logger_mock = mocker.MagicMock()
-    dwc_mock = mocker.patch("lta.rucio_stager.RucioStager._do_work_claim", new_callable=AsyncMock)
+    dwc_mock = mocker.patch("lta.rate_limiter.RateLimiter._do_work_claim", new_callable=AsyncMock)
     dwc_mock.return_value = False
-    p = RucioStager(config, logger_mock)
+    p = RateLimiter(config, logger_mock)
     await p._do_work()
     dwc_mock.assert_called()
 
 @pytest.mark.asyncio
-async def test_rucio_stager_do_work_yes_results(config, mocker):
+async def test_rate_limiter_do_work_yes_results(config, mocker):
     """Test that _do_work keeps working until the LTA DB has no work."""
     logger_mock = mocker.MagicMock()
-    dwc_mock = mocker.patch("lta.rucio_stager.RucioStager._do_work_claim", new_callable=AsyncMock)
+    dwc_mock = mocker.patch("lta.rate_limiter.RateLimiter._do_work_claim", new_callable=AsyncMock)
     dwc_mock.side_effect = [True, True, False]
-    p = RucioStager(config, logger_mock)
+    p = RateLimiter(config, logger_mock)
     await p._do_work()
     dwc_mock.assert_called()
 
 @pytest.mark.asyncio
-async def test_rucio_stager_do_work_claim_no_result(config, mocker):
+async def test_rate_limiter_do_work_claim_no_result(config, mocker):
     """Test that _do_work_claim does not work when the LTA DB has no work."""
     logger_mock = mocker.MagicMock()
     lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
     lta_rc_mock.return_value = {
         "bundle": None
     }
-    sb_mock = mocker.patch("lta.rucio_stager.RucioStager._stage_bundle", new_callable=AsyncMock)
-    p = RucioStager(config, logger_mock)
+    sb_mock = mocker.patch("lta.rate_limiter.RateLimiter._stage_bundle", new_callable=AsyncMock)
+    p = RateLimiter(config, logger_mock)
     await p._do_work_claim()
     lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=NERSC&status=created', {'claimant': f'{p.name}-{p.instance_uuid}'})
     sb_mock.assert_not_called()
 
 @pytest.mark.asyncio
-async def test_rucio_stager_do_work_claim_yes_result(config, mocker):
+async def test_rate_limiter_do_work_claim_yes_result(config, mocker):
     """Test that _do_work_claim processes the Bundle that it gets from the LTA DB."""
     logger_mock = mocker.MagicMock()
     lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
@@ -202,14 +204,14 @@ async def test_rucio_stager_do_work_claim_yes_result(config, mocker):
             "one": 1,
         },
     }
-    sb_mock = mocker.patch("lta.rucio_stager.RucioStager._stage_bundle", new_callable=AsyncMock)
-    p = RucioStager(config, logger_mock)
+    sb_mock = mocker.patch("lta.rate_limiter.RateLimiter._stage_bundle", new_callable=AsyncMock)
+    p = RateLimiter(config, logger_mock)
     assert not await p._do_work_claim()
     lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=NERSC&status=created', {'claimant': f'{p.name}-{p.instance_uuid}'})
     sb_mock.assert_called_with(mocker.ANY, {"one": 1})
 
 @pytest.mark.asyncio
-async def test_rucio_stager_stage_bundle_raises(config, mocker):
+async def test_rate_limiter_stage_bundle_raises(config, mocker):
     """Test that _do_work_claim both calls _quarantine_bundle and re-raises when _stage_bundle raises."""
     logger_mock = mocker.MagicMock()
     lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
@@ -218,10 +220,10 @@ async def test_rucio_stager_stage_bundle_raises(config, mocker):
             "one": 1,
         },
     }
-    sb_mock = mocker.patch("lta.rucio_stager.RucioStager._stage_bundle", new_callable=AsyncMock)
-    qb_mock = mocker.patch("lta.rucio_stager.RucioStager._quarantine_bundle", new_callable=AsyncMock)
+    sb_mock = mocker.patch("lta.rate_limiter.RateLimiter._stage_bundle", new_callable=AsyncMock)
+    qb_mock = mocker.patch("lta.rate_limiter.RateLimiter._quarantine_bundle", new_callable=AsyncMock)
     sb_mock.side_effect = Exception("LTA DB unavailable; currently safer at home")
-    p = RucioStager(config, logger_mock)
+    p = RateLimiter(config, logger_mock)
     with pytest.raises(Exception):
         await p._do_work_claim()
     lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=NERSC&status=created', {'claimant': f'{p.name}-{p.instance_uuid}'})
@@ -229,14 +231,14 @@ async def test_rucio_stager_stage_bundle_raises(config, mocker):
     qb_mock.assert_called_with(mocker.ANY, {"one": 1}, "LTA DB unavailable; currently safer at home")
 
 @pytest.mark.asyncio
-async def test_rucio_stager_stage_bundle(config, mocker):
+async def test_rate_limiter_stage_bundle(config, mocker):
     """Test that _stage_bundle attempts to stage a Bundle."""
     logger_mock = mocker.MagicMock()
     lta_rc_mock = mocker.patch("rest_tools.client.RestClient", new_callable=AsyncMock)
     move_mock = mocker.patch("shutil.move", new_callable=MagicMock)
     gfas_mock = mocker.patch("lta.lta_cmd._get_files_and_size", new_callable=MagicMock)
     gfas_mock.return_value = ([], 0)
-    p = RucioStager(config, logger_mock)
+    p = RateLimiter(config, logger_mock)
     await p._stage_bundle(lta_rc_mock, {
         "uuid": "c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003",
         "bundle_path": "/icecube/datawarehouse/path/to/c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003.zip",
@@ -246,15 +248,15 @@ async def test_rucio_stager_stage_bundle(config, mocker):
     lta_rc_mock.request.assert_called_with("PATCH", "/Bundles/c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003", mocker.ANY)
 
 @pytest.mark.asyncio
-async def test_rucio_stager_stage_bundle_over_quota(config, mocker):
+async def test_rate_limiter_stage_bundle_over_quota(config, mocker):
     """Test that _stage_bundle attempts to unclaim a Bundle when over quota."""
     logger_mock = mocker.MagicMock()
     lta_rc_mock = mocker.patch("rest_tools.client.RestClient", new_callable=AsyncMock)
     move_mock = mocker.patch("shutil.move", new_callable=MagicMock)
-    gfas_mock = mocker.patch("lta.rucio_stager._get_files_and_size", new_callable=MagicMock)
+    gfas_mock = mocker.patch("lta.rate_limiter._get_files_and_size", new_callable=MagicMock)
     gfas_mock.return_value = (["/path/to/one/file.zip"], 11826192449536)
-    ub_mock = mocker.patch("lta.rucio_stager.RucioStager._unclaim_bundle", new_callable=AsyncMock)
-    p = RucioStager(config, logger_mock)
+    ub_mock = mocker.patch("lta.rate_limiter.RateLimiter._unclaim_bundle", new_callable=AsyncMock)
+    p = RateLimiter(config, logger_mock)
     await p._stage_bundle(lta_rc_mock, {
         "uuid": "c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003",
         "bundle_path": "/icecube/datawarehouse/path/to/c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003.zip",
@@ -269,19 +271,19 @@ async def test_rucio_stager_stage_bundle_over_quota(config, mocker):
     move_mock.assert_not_called()
 
 @pytest.mark.asyncio
-async def test_rucio_stager_quarantine_bundle_with_reason(config, mocker):
+async def test_rate_limiter_quarantine_bundle_with_reason(config, mocker):
     """Test that _do_work_claim attempts to quarantine a Bundle that fails to get deleted."""
     logger_mock = mocker.MagicMock()
     lta_rc_mock = mocker.patch("rest_tools.client.RestClient", new_callable=AsyncMock)
-    p = RucioStager(config, logger_mock)
+    p = RateLimiter(config, logger_mock)
     await p._quarantine_bundle(lta_rc_mock, {"uuid": "c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003"}, "Rucio caught fire, then we roasted marshmellows.")
     lta_rc_mock.request.assert_called_with("PATCH", "/Bundles/c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003", mocker.ANY)
 
 @pytest.mark.asyncio
-async def test_rucio_stager_unclaim_bundle(config, mocker):
+async def test_rate_limiter_unclaim_bundle(config, mocker):
     """Test that _unclaim_bundle attempts to update the LTA DB."""
     logger_mock = mocker.MagicMock()
     lta_rc_mock = mocker.patch("rest_tools.client.RestClient", new_callable=AsyncMock)
-    p = RucioStager(config, logger_mock)
+    p = RateLimiter(config, logger_mock)
     await p._unclaim_bundle(lta_rc_mock, {"uuid": "c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003"})
     lta_rc_mock.request.assert_called_with("PATCH", "/Bundles/c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003", mocker.ANY)


### PR DESCRIPTION
RucioStager is now RateLimiter with more generic configuration variables:
`INPUT_PATH`: Directory where bundle files are moved from
`OUTPUT_PATH`: Directory where bundle files are moved to
`OUTPUT_QUOTA`: Limit on total size of output directory

Closes #169 
