### PR TITLE
Add command: ltacmd catalog stats

### DIFF
--- a/lta/lta_cmd.py
+++ b/lta/lta_cmd.py
@@ -226,11 +226,9 @@ def _is_nersc_bundle_record(d: Dict[str, Any]) -> bool:
     """Determine if the provided catalog record is a bundle at NERSC."""
     # if we didn't get a record, this is not a bundle at NERSC
     if not d:
-        raise Exception("bad record")
         return False
     # if the record doesn't contain locations, this is not a bundle at NERSC
     if "locations" not in d:
-        raise Exception("no locations")
         return False
     # for each location
     all_good = False

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colorama==0.4.4
 flake8==3.9.2
 hurry.filesize==0.9
 motor==2.4.0
-mypy==0.812
+mypy==0.910
 prometheus-client==0.11.0
 pycycle==0.0.8
 pymongo==3.11.4


### PR DESCRIPTION
`ltacmd catalog stats` dumps records on bundles archived at NERSC.

This is important as every 6 months(ish), Benedikt needs some data/plot for reporting.
In the future, we'd probably like some dashboard that has an up-to-the-minute graph.
But for now, this command gave me what I needed for the latest report.

