### PR TITLE
Adds lta.date_archived field to bundle records in File Catalog

### DIFF
--- a/lta/desy_verifier.py
+++ b/lta/desy_verifier.py
@@ -117,6 +117,7 @@ class DesyVerifier(Component):
         basename = os.path.basename(bundle["bundle_path"])  # 604b6c80659c11eb8ad66224ddddaab7.zip
         desy_tape_path = join_smart([self.tape_base_path, data_warehouse_path, basename])
         # create a File Catalog entry for the bundle itself
+        right_now = now()
         file_record = {
             "uuid": bundle["uuid"],
             "logical_name": desy_tape_path,
@@ -129,6 +130,9 @@ class DesyVerifier(Component):
                 }
             ],
             "file_size": bundle["size"],
+            "lta": {
+                "date_archived": right_now,
+            },
         }
         # add the bundle file to the File Catalog
         try:

--- a/lta/nersc_verifier.py
+++ b/lta/nersc_verifier.py
@@ -137,6 +137,7 @@ class NerscVerifier(Component):
         hpss_path = os.path.normpath(stupid_python_path)
         # create a File Catalog entry for the bundle itself
         bundle_uuid = bundle["uuid"]
+        right_now = now()
         file_record = {
             "uuid": bundle_uuid,
             "logical_name": hpss_path,
@@ -150,6 +151,9 @@ class NerscVerifier(Component):
                 }
             ],
             "file_size": bundle["size"],
+            "lta": {
+                "date_archived": right_now,
+            },
         }
         # add the bundle file to the File Catalog
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-binpacking==1.4.5
+binpacking==1.5.0
 colorama==0.4.4
 flake8==3.9.2
 hurry.filesize==0.9

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colorama==0.4.4
 flake8==3.9.2
 hurry.filesize==0.9
 motor==2.4.0
-mypy==0.812
+mypy==0.910
 prometheus-client==0.11.0
 pycycle==0.0.8
 pymongo==3.11.4


### PR DESCRIPTION
Modifies DesyVerifier and NerscVerifier to add a `lta.date_archived` field to the File Catalog record for bundle files stored at DESY/NERSC.

Closes #203 
