### PR TITLE
Bump rest_tools dependency to v0.1.14

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ pytest-asyncio==0.15.1
 pytest-cov==2.12.1
 pytest-mock==3.6.1
 requests==2.26.0
-git+https://github.com/WIPACrepo/rest-tools@v1.1.12#egg=rest_tools
+git+https://github.com/WIPACrepo/rest-tools@v1.1.14#egg=rest_tools
 tornado==6.1


### PR DESCRIPTION
`TypedDict` is not available in Python 3.6, which is currently available at NERSC.

    ImportError: cannot import name 'TypedDict'

@ric-evans fixed up the dependency in wipac-telemetry:
https://github.com/WIPACrepo/wipac-telemetry-prototype/pull/33

Then bumped to that version in rest-tools:
https://github.com/WIPACrepo/rest-tools/pull/39

This PR bumps LTA to the newest version of rest-tools, which should make LTA usable at NERSC again.
