### PR TITLE
Clean up GET /Metadata query

### DIFF
--- a/lta/lta_cmd.py
+++ b/lta/lta_cmd.py
@@ -627,7 +627,7 @@ async def metadata_ls(args: Namespace) -> ExitCode:
             print_dict_as_pretty_json(obj)
         return EXIT_OK
     if args.uuid:
-        response = await args.di["lta_rc"].request("DELETE", f"/Metadata/{args.uuid}")
+        response = await args.di["lta_rc"].request("GET", f"/Metadata/{args.uuid}")
         if args.json:
             print_dict_as_pretty_json(response)
         else:

--- a/lta/rest_server.py
+++ b/lta/rest_server.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta
 from functools import wraps
 import logging
 import os
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, Dict
 from urllib.parse import quote_plus
 from uuid import uuid1
 

--- a/lta/rest_server.py
+++ b/lta/rest_server.py
@@ -438,20 +438,17 @@ class MetadataHandler(BaseLTAHandler):
         skip = int(self.get_query_argument("skip", default=0))
 
         query: Dict[str, Any] = {
-            "uuid": {"$exists": True},
             "bundle_uuid": bundle_uuid,
         }
 
         projection: Dict[str, bool] = {"_id": False}
-        sort: List[Tuple[str, Any]] = [("uuid", ASCENDING)]
 
         results = []
         logging.debug(f"MONGO-START: db.Metadata.find(filter={query}, projection={projection}, limit={limit}, skip={skip})")
         async for row in self.db.Metadata.find(filter=query,
                                                projection=projection,
                                                skip=skip,
-                                               limit=limit,
-                                               sort=sort):
+                                               limit=limit):
             results.append(row)
         logging.debug("MONGO-END*:   db.Metadata.find(filter, projection, limit, skip)")
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,5 +12,5 @@ pytest-asyncio==0.16.0
 pytest-cov==3.0.0
 pytest-mock==3.6.1
 requests==2.26.0
-git+https://github.com/WIPACrepo/rest-tools@v1.1.19#egg=rest_tools
+git+https://github.com/WIPACrepo/rest-tools@v1.1.20#egg=rest_tools
 tornado==6.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ flake8==4.0.1
 hurry.filesize==0.9
 motor==2.5.1
 mypy==0.910
-prometheus-client==0.11.0
+prometheus-client==0.12.0
 pycycle==0.0.8
 pymongo==3.12.1
 pytest==6.2.5
@@ -12,5 +12,5 @@ pytest-asyncio==0.16.0
 pytest-cov==3.0.0
 pytest-mock==3.6.1
 requests==2.26.0
-git+https://github.com/WIPACrepo/rest-tools@v1.1.14#egg=rest_tools
+git+https://github.com/WIPACrepo/rest-tools@v1.1.19#egg=rest_tools
 tornado==6.1


### PR DESCRIPTION
Simplifies the GET /Metadata query by removing an `$exists` filter and a sort.

This also fixes up a bug where using ltacmd to list a Metadata entity by UUID (`ltacmd metadata ls --uuid UUID`) would DELETE the entity instead of listing it!

Closes #214
