### PR TITLE
Trim down some async warnings

### DIFF
--- a/tests/test_component.py
+++ b/tests/test_component.py
@@ -2,7 +2,7 @@
 """Unit tests for lta/picker.py."""
 
 from asyncio import Future
-from unittest.mock import call, MagicMock
+from unittest.mock import AsyncMock, call, MagicMock
 from uuid import uuid1
 
 import pytest  # type: ignore
@@ -11,7 +11,8 @@ from tornado.web import HTTPError  # type: ignore
 
 from lta.component import patch_status_heartbeat, status_loop, work_loop
 from lta.picker import main, Picker
-from .test_util import AsyncMock, ObjectLiteral
+from .test_util import ObjectLiteral
+
 
 @pytest.fixture
 def config():

--- a/tests/test_desy_move_verifier.py
+++ b/tests/test_desy_move_verifier.py
@@ -1,13 +1,13 @@
 # test_desy_move_verifier.py
 """Unit tests for lta/desy_move_verifier.py."""
 
-from unittest.mock import call
+from unittest.mock import AsyncMock, call
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.desy_move_verifier import main, DesyMoveVerifier
-from .test_util import AsyncMock
+
 
 @pytest.fixture
 def config():

--- a/tests/test_desy_verifier.py
+++ b/tests/test_desy_verifier.py
@@ -1,14 +1,14 @@
 # test_desy_verifier.py
 """Unit tests for lta/desy_verifier.py."""
 
-from unittest.mock import call
+from unittest.mock import AsyncMock, call
 from uuid import uuid1
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.desy_verifier import main, DesyVerifier
-from .test_util import AsyncMock
+
 
 @pytest.fixture
 def config():

--- a/tests/test_locator.py
+++ b/tests/test_locator.py
@@ -4,14 +4,14 @@
 from math import floor
 from secrets import token_hex
 from typing import Dict, List, Union
-from unittest.mock import call, MagicMock
+from unittest.mock import AsyncMock, call, MagicMock
 from uuid import uuid1
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.locator import as_lta_record, main, Locator
-from .test_util import AsyncMock
+
 
 @pytest.fixture
 def config():

--- a/tests/test_monitoring.py
+++ b/tests/test_monitoring.py
@@ -3,12 +3,12 @@
 
 import asyncio
 import socket
+from unittest.mock import AsyncMock
 
 import pytest  # type: ignore
 import requests
 
 import lta.monitoring
-from .test_util import AsyncMock
 
 
 @pytest.fixture

--- a/tests/test_nersc_mover.py
+++ b/tests/test_nersc_mover.py
@@ -1,13 +1,13 @@
 # test_nersc_mover.py
 """Unit tests for lta/nersc_mover.py."""
 
-from unittest.mock import call, MagicMock
+from unittest.mock import AsyncMock, call, MagicMock
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.nersc_mover import main, NerscMover
-from .test_util import AsyncMock, ObjectLiteral
+from .test_util import ObjectLiteral
 
 @pytest.fixture
 def config():
@@ -340,8 +340,8 @@ async def test_nersc_mover_write_bundle_to_hpss_mkdir(config, mocker):
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    request_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
+    request_mock.side_effect = [
         {
             "bundle": {
                 "uuid": "398ca1ed-0178-4333-a323-8b9158c3dd88",
@@ -354,8 +354,8 @@ async def test_nersc_mover_write_bundle_to_hpss_mkdir(config, mocker):
     ehc_mock.return_value = False
     p = NerscMover(config, logger_mock)
     await p._do_work_claim()
-    ehc_mock.assert_called_with(lta_rc_mock, mocker.ANY, ['/usr/bin/hsi', 'mkdir', '-p', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109'])
-    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=NERSC&status=taping', {'claimant': f'{p.name}-{p.instance_uuid}'})
+    ehc_mock.assert_called_with(mocker.ANY, mocker.ANY, ['/usr/bin/hsi', 'mkdir', '-p', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109'])
+    request_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=NERSC&status=taping', {'claimant': f'{p.name}-{p.instance_uuid}'})
 
 
 @pytest.mark.asyncio
@@ -369,8 +369,8 @@ async def test_nersc_mover_write_bundle_to_hpss_hsi_put(config, mocker):
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    request_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
+    request_mock.side_effect = [
         {
             "bundle": {
                 "uuid": "398ca1ed-0178-4333-a323-8b9158c3dd88",
@@ -383,8 +383,8 @@ async def test_nersc_mover_write_bundle_to_hpss_hsi_put(config, mocker):
     ehc_mock.side_effect = [True, False]
     p = NerscMover(config, logger_mock)
     await p._do_work_claim()
-    ehc_mock.assert_called_with(lta_rc_mock, mocker.ANY, ['/usr/bin/hsi', 'put', '-c', 'on', '-H', 'sha512', '/path/to/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip', ':', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'])
-    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=NERSC&status=taping', {'claimant': f'{p.name}-{p.instance_uuid}'})
+    ehc_mock.assert_called_with(mocker.ANY, mocker.ANY, ['/usr/bin/hsi', 'put', '-c', 'on', '-H', 'sha512', '/path/to/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip', ':', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'])
+    request_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=NERSC&status=taping', {'claimant': f'{p.name}-{p.instance_uuid}'})
 
 
 @pytest.mark.asyncio
@@ -398,8 +398,8 @@ async def test_nersc_mover_write_bundle_to_hpss(config, mocker):
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    request_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
+    request_mock.side_effect = [
         {
             "bundle": {
                 "uuid": "398ca1ed-0178-4333-a323-8b9158c3dd88",
@@ -415,8 +415,8 @@ async def test_nersc_mover_write_bundle_to_hpss(config, mocker):
     ehc_mock.side_effect = [True, True]
     p = NerscMover(config, logger_mock)
     await p._do_work_claim()
-    ehc_mock.assert_called_with(lta_rc_mock, mocker.ANY, ['/usr/bin/hsi', 'put', '-c', 'on', '-H', 'sha512', '/path/to/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip', ':', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'])
-    lta_rc_mock.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
+    ehc_mock.assert_called_with(mocker.ANY, mocker.ANY, ['/usr/bin/hsi', 'put', '-c', 'on', '-H', 'sha512', '/path/to/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip', ':', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'])
+    request_mock.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
 
 
 @pytest.mark.asyncio

--- a/tests/test_nersc_retriever.py
+++ b/tests/test_nersc_retriever.py
@@ -1,13 +1,14 @@
 # test_nersc_retriever.py
 """Unit tests for lta/nersc_retriever.py."""
 
-from unittest.mock import call, MagicMock
+from unittest.mock import AsyncMock, call, MagicMock
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.nersc_retriever import main, NerscRetriever
-from .test_util import AsyncMock, ObjectLiteral
+from .test_util import ObjectLiteral
+
 
 @pytest.fixture
 def config():
@@ -340,8 +341,8 @@ async def test_nersc_retriever_read_bundle_from_hpss_hsi_get(config, mocker):
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    request_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
+    request_mock.side_effect = [
         {
             "bundle": {
                 "uuid": "398ca1ed-0178-4333-a323-8b9158c3dd88",
@@ -357,8 +358,8 @@ async def test_nersc_retriever_read_bundle_from_hpss_hsi_get(config, mocker):
     ehc_mock.side_effect = [True, False]
     p = NerscRetriever(config, logger_mock)
     await p._do_work_claim()
-    ehc_mock.assert_called_with(lta_rc_mock, mocker.ANY, ['/usr/bin/hsi', 'get', '-c', 'on', '/path/to/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip', ':', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'])
-    lta_rc_mock.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
+    ehc_mock.assert_called_with(mocker.ANY, mocker.ANY, ['/usr/bin/hsi', 'get', '-c', 'on', '/path/to/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip', ':', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'])
+    request_mock.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
 
 
 @pytest.mark.asyncio
@@ -372,8 +373,8 @@ async def test_nersc_retriever_read_bundle_from_hpss(config, mocker):
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    request_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
+    request_mock.side_effect = [
         {
             "bundle": {
                 "uuid": "398ca1ed-0178-4333-a323-8b9158c3dd88",
@@ -389,8 +390,8 @@ async def test_nersc_retriever_read_bundle_from_hpss(config, mocker):
     ehc_mock.side_effect = [True, True]
     p = NerscRetriever(config, logger_mock)
     await p._do_work_claim()
-    ehc_mock.assert_called_with(lta_rc_mock, mocker.ANY, ['/usr/bin/hsi', 'get', '-c', 'on', '/path/to/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip', ':', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'])
-    lta_rc_mock.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
+    ehc_mock.assert_called_with(mocker.ANY, mocker.ANY, ['/usr/bin/hsi', 'get', '-c', 'on', '/path/to/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip', ':', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'])
+    request_mock.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
 
 
 @pytest.mark.asyncio

--- a/tests/test_nersc_verifier.py
+++ b/tests/test_nersc_verifier.py
@@ -1,14 +1,14 @@
 # test_nersc_verifier.py
 """Unit tests for lta/nersc_verifier.py."""
 
-from unittest.mock import call, MagicMock
+from unittest.mock import AsyncMock, call, MagicMock
 from uuid import uuid1
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.nersc_verifier import main, NerscVerifier
-from .test_util import AsyncMock, ObjectLiteral
+from .test_util import ObjectLiteral
 
 @pytest.fixture
 def config():

--- a/tests/test_picker.py
+++ b/tests/test_picker.py
@@ -3,14 +3,14 @@
 
 from secrets import token_hex
 from typing import Dict, List, Union
-from unittest.mock import call, MagicMock
+from unittest.mock import AsyncMock, call, MagicMock
 from uuid import uuid1
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.picker import CREATE_CHUNK_SIZE, main, Picker
-from .test_util import AsyncMock
+
 
 FILE_CATALOG_LIMIT = 9000
 

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -1,13 +1,13 @@
 # test_rate_limiter.py
 """Unit tests for lta/rate_limiter.py."""
 
-from unittest.mock import call, MagicMock
+from unittest.mock import AsyncMock, call, MagicMock
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.rate_limiter import main, RateLimiter
-from .test_util import AsyncMock
+
 
 @pytest.fixture
 def config():

--- a/tests/test_rest_server.py
+++ b/tests/test_rest_server.py
@@ -64,6 +64,7 @@ def port():
     return ephemeral_port
 
 @pytest.fixture
+@pytest.mark.asyncio
 async def rest(monkeypatch, port):
     """Provide RestClient as a test fixture."""
     monkeypatch.setenv("LTA_AUTH_ALGORITHM", "HS512")
@@ -88,7 +89,7 @@ async def rest(monkeypatch, port):
         return RestClient(f'http://localhost:{port}', token=t, timeout=timeout, retries=0)
 
     yield client
-    s.stop()
+    await s.stop()
     await asyncio.sleep(0.01)
 
 # -----------------------------------------------------------------------------

--- a/tests/test_site_move_verifier.py
+++ b/tests/test_site_move_verifier.py
@@ -1,14 +1,15 @@
 # test_site_move_verifier.py
 """Unit tests for lta/site_move_verifier.py."""
 
-from unittest.mock import call, MagicMock
+from unittest.mock import AsyncMock, call, MagicMock
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.site_move_verifier import as_nonempty_columns, discard_empty, MYQUOTA_ARGS, parse_myquota
 from lta.site_move_verifier import main, SiteMoveVerifier
-from .test_util import AsyncMock, ObjectLiteral
+from .test_util import ObjectLiteral
+
 
 @pytest.fixture
 def config():

--- a/tests/test_transfer_request_finisher.py
+++ b/tests/test_transfer_request_finisher.py
@@ -1,13 +1,13 @@
 # test_transfer_request_finisher.py
 """Unit tests for lta/transfer_request_finisher.py."""
 
-from unittest.mock import call  # MagicMock
+from unittest.mock import AsyncMock, call
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.transfer_request_finisher import main, TransferRequestFinisher
-from .test_util import AsyncMock
+
 
 @pytest.fixture
 def config():

--- a/tests/test_unpacker.py
+++ b/tests/test_unpacker.py
@@ -1,13 +1,12 @@
 # test_unpacker.py
 """Unit tests for lta/unpacker.py."""
 
-from unittest.mock import call, mock_open, patch
+from unittest.mock import AsyncMock, call, mock_open, patch
 
 import pytest  # type: ignore
 from tornado.web import HTTPError  # type: ignore
 
 from lta.unpacker import Unpacker, main
-from .test_util import AsyncMock
 
 
 @pytest.fixture
@@ -257,15 +256,15 @@ async def test_unpacker_do_work_yes_results(config, mocker, path_map_mock):
         "uuid": "f74db80e-9661-40cc-9f01-8d087af23f56"
     }
     logger_mock = mocker.MagicMock()
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.return_value = {
+    request_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
+    request_mock.return_value = {
         "bundle": BUNDLE_OBJ,
     }
     dwb_mock = mocker.patch("lta.unpacker.Unpacker._do_work_bundle", new_callable=AsyncMock)
     p = Unpacker(config, logger_mock)
     assert await p._do_work_claim()
-    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=NERSC&dest=WIPAC&status=unpacking', mocker.ANY)
-    dwb_mock.assert_called_with(lta_rc_mock, BUNDLE_OBJ)
+    request_mock.assert_called_with("POST", '/Bundles/actions/pop?source=NERSC&dest=WIPAC&status=unpacking', mocker.ANY)
+    dwb_mock.assert_called_with(mocker.ANY, BUNDLE_OBJ)
 
 
 @pytest.mark.asyncio
@@ -275,8 +274,8 @@ async def test_unpacker_do_work_raise_exception(config, mocker, path_map_mock):
         "uuid": "f74db80e-9661-40cc-9f01-8d087af23f56"
     }
     logger_mock = mocker.MagicMock()
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.return_value = {
+    request_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
+    request_mock.return_value = {
         "bundle": BUNDLE_OBJ,
     }
     dwb_mock = mocker.patch("lta.unpacker.Unpacker._do_work_bundle", new_callable=AsyncMock)
@@ -285,9 +284,9 @@ async def test_unpacker_do_work_raise_exception(config, mocker, path_map_mock):
     p = Unpacker(config, logger_mock)
     with pytest.raises(Exception):
         await p._do_work_claim()
-    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=NERSC&dest=WIPAC&status=unpacking', mocker.ANY)
-    dwb_mock.assert_called_with(lta_rc_mock, BUNDLE_OBJ)
-    qb_mock.assert_called_with(lta_rc_mock, BUNDLE_OBJ, "LTA DB started on fire again")
+    request_mock.assert_called_with("POST", '/Bundles/actions/pop?source=NERSC&dest=WIPAC&status=unpacking', mocker.ANY)
+    dwb_mock.assert_called_with(mocker.ANY, BUNDLE_OBJ)
+    qb_mock.assert_called_with(mocker.ANY, BUNDLE_OBJ, "LTA DB started on fire again")
 
 
 @pytest.mark.asyncio

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,24 +1,6 @@
 # test_util.py
 """Module to provide testing utility functions, objects, etc."""
 
-from unittest.mock import MagicMock
-
-
-class AsyncMock(MagicMock):
-    """
-    AsyncMock is the async version of a MagicMock.
-
-    We use this class in place of MagicMock when we want to mock
-    asynchronous callables.
-
-    Source: https://stackoverflow.com/a/32498408
-    """
-
-    async def __call__(self, *args, **kwargs):
-        """Allow MagicMock to work its magic too."""
-        return super(AsyncMock, self).__call__(*args, **kwargs)
-
-
 class ObjectLiteral:
     """
     ObjectLiteral transforms named arguments into object attributes.


### PR DESCRIPTION
As discussed with David and Ric on Slack the other day, there are a few warnings we can trim down in the tests.

`AsyncMockMixin._execute_mock_call` is a bit more tricky.

https://bugs.python.org/issue40406

This PR also replaces a home-rolled `AsyncMock` with the official `AsyncMock` from Python 3.8
