### PR TITLE
Allow rate-limiter to ignore missing bundles in the destination check

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,9 @@ For Linux Mint 18, there is a script in the resources directory:
     resources/install-docker.sh
 
 #### Install circleci-cli
-As root, the following command installs circleci-cli locally:
+The following command installs circleci-cli locally:
 
-    curl -fLSs https://circle.ci/cli | bash
+    curl -fLSs https://raw.githubusercontent.com/CircleCI-Public/circleci-cli/master/install.sh | sudo bash
 
 There are [other installation options](https://github.com/CircleCI-Public/circleci-cli) as well.
 

--- a/lta/rate_limiter.py
+++ b/lta/rate_limiter.py
@@ -81,9 +81,9 @@ class RateLimiter(Component):
             try:
                 # determine the size of the file
                 size += os.path.getsize(disk_file)
-            except:
+            except Exception as e:
                 # whoops, looks like somebody downstream moved it
-                self.logger.error(f"Skipped getsize() on missing file: {disk_file}")
+                self.logger.error(f"Skipped getsize() on missing file: {disk_file}", exc_info=e)
                 continue
             self.logger.debug(f"Size so far: {size} bytes")
         self.logger.info(f"Found {len(disk_files)} entries ({size} bytes) in {path}")

--- a/lta/rate_limiter.py
+++ b/lta/rate_limiter.py
@@ -84,6 +84,18 @@ class RateLimiter(Component):
         self.logger.info(f"Found {len(disk_files)} entries ({size} bytes) in {path}")
         return (disk_files, size)
 
+    def _get_files_and_size_with_retry(self, path: str) -> Tuple[List[str], int]:
+        """Recursively walk and add the files of files in the file system."""
+        retry_left = 3
+        while retry_left > 0:
+            retry_left = retry_left - 1
+            try:
+                return self._get_files_and_size(path)
+            except Exception as e:
+                self.logger.error(f"Error while checking the contents of {path}:", exc_info=e)
+                self.logger.error(f"Will attempt to retry up to {retry_left} more time(s).")
+        raise Exception(f"Ran out of retries while checking the contents of {path}")
+
     @wtt.spanned()
     async def _do_work(self) -> None:
         """Perform a work cycle for this component."""
@@ -145,7 +157,7 @@ class RateLimiter(Component):
         """Stage the Bundle to the output directory for transfer."""
         bundle_id = bundle["uuid"]
         # measure output directory size, our bundle's size, and the quota
-        output_size = self._get_files_and_size(self.output_path)[1]
+        output_size = self._get_files_and_size_with_retry(self.output_path)[1]
         bundle_size = bundle["size"]
         total_size = output_size + bundle_size
         # if we would exceed our destination quota

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ colorama==0.4.4
 flake8==4.0.1
 hurry.filesize==0.9
 motor==2.5.1
-mypy==0.920
+mypy==0.921
 prometheus-client==0.12.0
 pycycle==0.0.8
 pymongo==3.12.1

--- a/tests/test_rate_limiter.py
+++ b/tests/test_rate_limiter.py
@@ -287,3 +287,29 @@ async def test_rate_limiter_unclaim_bundle(config, mocker):
     p = RateLimiter(config, logger_mock)
     await p._unclaim_bundle(lta_rc_mock, {"uuid": "c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003"})
     lta_rc_mock.request.assert_called_with("PATCH", "/Bundles/c4b345e4-2395-4f9e-b0eb-9cc1c9cdf003", mocker.ANY)
+
+def test_get_files_and_size_with_retry_will_retry(config, mocker):
+    """Test that retries work when an exception is thrown."""
+    logger_mock = mocker.MagicMock()
+    gfas_mock = mocker.patch("lta.rate_limiter.RateLimiter._get_files_and_size", new_callable=MagicMock)
+    gfas_mock.side_effect = [
+        Exception("file system on fire"),
+        ([], 0),    # it's okay, we put the fire out so it worked this time
+    ]
+    p = RateLimiter(config, logger_mock)
+    assert p._get_files_and_size_with_retry("/path/to/destination/directory") == ([], 0)
+
+def test_get_files_and_size_with_retry_will_exhaust_retries(config, mocker):
+    """Test that retries work until they don't."""
+    logger_mock = mocker.MagicMock()
+    gfas_mock = mocker.patch("lta.rate_limiter.RateLimiter._get_files_and_size", new_callable=MagicMock)
+    gfas_mock.side_effect = [
+        Exception("file system on fire"),
+        Exception("file system still on fire"),
+        Exception("file system still ablaze"),
+        Exception("file system fire spreading to office"),
+        Exception("file system is burning down the whole block"),
+    ]
+    p = RateLimiter(config, logger_mock)
+    with pytest.raises(Exception):
+        p._get_files_and_size_with_retry("/path/to/destination/directory")


### PR DESCRIPTION
This modifies the rate-limiter component to retry when bundles in the destination directory are removed when the rate-limiter is in the middle of counting and sizing the files in the destination directory.

Fixes #222 
