### PR TITLE
Use better event loop management

### DIFF
--- a/lta/lta_cmd.py
+++ b/lta/lta_cmd.py
@@ -1198,4 +1198,4 @@ async def main() -> None:
 
 if __name__ == '__main__':
     logging.basicConfig(level=logging.CRITICAL)
-    asyncio.get_event_loop().run_until_complete(main())
+    asyncio.run(main())

--- a/ltacmd
+++ b/ltacmd
@@ -13,5 +13,6 @@ export FILE_CATALOG_REST_TOKEN=${FILE_CATALOG_REST_TOKEN:="$(<service-token)"}
 export FILE_CATALOG_REST_URL=${FILE_CATALOG_REST_URL:="https://file-catalog.icecube.wisc.edu"}
 export LTA_REST_TOKEN=${LTA_REST_TOKEN:="$(<service-token)"}
 export LTA_REST_URL=${LTA_REST_URL:="https://lta.icecube.aq"}
+export PYTHONWARNINGS=${PYTHONWARNINGS:="ignore"}
 # run the command
 python -m lta.lta_cmd $@


### PR DESCRIPTION
* Fixes Python 3.10 deprecation
* Suppresses deprecation warnings by default when using `ltacmd` script
