### PR TITLE
Modify parameters for small transfer requests

### DIFF
--- a/lta/lta_cmd.py
+++ b/lta/lta_cmd.py
@@ -53,7 +53,8 @@ EXPECTED_CONFIG = {
 KILOBYTE = 1024
 MEGABYTE = KILOBYTE * KILOBYTE
 GIGABYTE = MEGABYTE * KILOBYTE
-MINIMUM_REQUEST_SIZE = 100 * GIGABYTE
+# MINIMUM_REQUEST_SIZE = 100 * GIGABYTE
+MINIMUM_REQUEST_SIZE = 75 * 1000**3
 
 PATH_PREFIX_ALLOW_LIST = [
     "/data/ana",
@@ -728,6 +729,9 @@ async def request_new(args: Namespace) -> ExitCode:
     source = args.source
     dest = args.dest
     path = normalize_path(args.path)
+    # if the request contains nothing at all, don't try to archive it
+    if (size == 0) or (len(disk_files) == 0):
+        raise Exception(f"TransferRequest for {path}\n{size:,} bytes ({hurry.filesize.size(size)}) in {len(disk_files):,} files.\nWill NOT attempt to archive 0 bytes.")
     # if it doesn't meet our minimize size requirement
     if size < MINIMUM_REQUEST_SIZE:
         # and the operator has not forced the issue

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ hurry.filesize==0.9
 motor==2.5.1
 mypy==0.942
 prometheus-client==0.14.1
+protobuf >= 3.13.0, < 4.0
 pycycle==0.0.8
 pyjwt[crypto]
 pymongo==3.12.3


### PR DESCRIPTION
* Lowers regular minimum size from 100 GiB to 75 GB.
* Adds a check that transfer requests containing 0 files and/or 0 bytes cannot be archived (even with `--force`)
