### PR TITLE
Add -debug flag to grid-proxy-init

### DIFF
--- a/lta/transfer/globus.py
+++ b/lta/transfer/globus.py
@@ -80,7 +80,7 @@ class SiteGlobusProxy(object):
                     cmd.extend(['-voms', cast(str, self.cfg['GLOBUS_PROXY_VOMS_VO'])])
             else:
                 cmd = ['grid-proxy-init']
-            cmd.extend(['-pwstdin', '-valid', f'{int(self.cfg["GLOBUS_PROXY_DURATION"])+1}:0'])
+            cmd.extend(['-debug', '-pwstdin', '-valid', f'{int(self.cfg["GLOBUS_PROXY_DURATION"])+1}:0'])
             if 'GLOBUS_PROXY_OUTPUT' in self.cfg and self.cfg['GLOBUS_PROXY_OUTPUT']:
                 cmd.extend(['-out', cast(str, self.cfg['GLOBUS_PROXY_OUTPUT'])])
             inputbytes = (cast(str, self.cfg['GLOBUS_PROXY_PASSPHRASE']) + '\n').encode('utf-8')

--- a/lta/transfer/gridftp.py
+++ b/lta/transfer/gridftp.py
@@ -171,7 +171,12 @@ class GridFTP(object):
         return None
 
     @classmethod
-    def put(cls, address: str, data: Optional[str] = None, filename: Optional[str] = None, request_timeout: Optional[int] = None) -> None:
+    def put(cls,
+            address: str,
+            data: Optional[str] = None,
+            filename: Optional[str] = None,
+            request_timeout: Optional[int] = None,
+            debug: Optional[bool] = False) -> None:
         """
         Do a GridFTP put request.
 
@@ -182,6 +187,7 @@ class GridFTP(object):
             data (str): the data to put
             filename (str): filename for data to put
             request_timeout (float): timeout in seconds
+            debug (bool): add -dbg flag for debug output to stderr
 
         Raises:
             Exception for failure
@@ -201,6 +207,8 @@ class GridFTP(object):
             raise Exception('Neither data or filename is defined')
 
         cmd = ['globus-url-copy', '-cd', src, address]
+        if debug:
+            cmd = ['globus-url-copy', '-dbg', '-cd', src, address]
 
         if request_timeout is None:
             timeout = cls._timeout


### PR DESCRIPTION
It can't find the credentials yet, so we add a `-debug` flag to the command to get more information.

```text
2023-05-15 21:18:18,334 [ThreadPoolExecutor-3_0] DEBUG (connectionpool.py:546) - https://lta.icecube.aq:443 "POST /Bundles/actions/pop?source=WIPAC&dest=NERSC&status=staged HTTP/1.1" 200 880
2023-05-15 21:18:18,335 [MainThread] INFO  (gridftp_replicator.py:106) - LTA DB responded with: {'bundle': {'type': 'Bundle', 'status': 'staged', 'reason': '', 'request': '2ef5a210eed711edb24ec24a9890dca8', 'source': 'WIPAC', 'dest': 'NERSC', 'path': '/data/exp/IceCube/2022/unbiased/PFRaw/0714', 'file_count': 66, 'uuid': '4df86e36eed711edb24ec24a9890dca8', 'create_timestamp': '2023-05-10T02:06:41', 'update_timestamp': '2023-05-15T21:18:18', 'work_priority_timestamp': '2023-05-15T21:14:21', 'claimed': True, 'claim_timestamp': '2023-05-15T21:18:18', 'claimant': 'long-term-archive-pipe0-gridftp-replicator-545b8c7bb6-64wp2-d1e243d3-16e3-4380-b8bc-3453024c9362', 'bundle_path': '/data/user/jade/ltatemp/bundler_out/4df86e36eed711edb24ec24a9890dca8.zip', 'checksum': {'adler32': '04b70fc1', 'sha512': '014edd5e3e473977e23b512b30a4ab672dac2b2f1338585fd844ee359864ed39d2cfbe36c33bf232b06d4925af28170f08c4dd05e46ec1adad7e3cf3316c4259'}, 'size': 77416509895, 'verified': False}}
2023-05-15 21:18:18,335 [MainThread] INFO  (gridftp_replicator.py:145) - Updating proxy credentials
2023-05-15 21:18:18,336 [MainThread] INFO  (globus.py:68) - duration: 72
2023-05-15 21:18:18,346 [MainThread] INFO  (globus.py:88) - proxy cmd: ['grid-proxy-init', '-pwstdin', '-valid', '73:0']
2023-05-15 21:18:18,346 [MainThread] INFO  (globus.py:89) - stdout: b''
2023-05-15 21:18:18,347 [MainThread] INFO  (globus.py:90) - stderr: b"Error: Couldn't find valid credentials to generate a proxy.\nUse -debug for further information.\n"
2023-05-15 21:18:18,347 [MainThread] ERROR (gridftp_replicator.py:126) - Sending Bundle 4df86e36eed711edb24ec24a9890dca8 to quarantine: grid-proxy-init failed.
2023-05-15 21:18:18,353 [ThreadPoolExecutor-3_0] DEBUG (connectionpool.py:546) - https://lta.icecube.aq:443 "PATCH /Bundles/4df86e36eed711edb24ec24a9890dca8 HTTP/1.1" 200 1002
```