### PR TITLE
Update LTA configuration to use Perlmutter Scratch instead of Cori Scratch

### DIFF
--- a/bin/deleter-nersc-return.sh
+++ b/bin/deleter-nersc-return.sh
@@ -7,7 +7,7 @@ export CLIENT_ID=${CLIENT_ID:="long-term-archive"}
 export CLIENT_SECRET=${CLIENT_SECRET:="$(<keycloak-client-secret)"}
 export COMPONENT_NAME=${COMPONENT_NAME:="$(hostname)-deleter-return"}
 export DEST_SITE=${DEST_SITE:="WIPAC"}
-export DISK_BASE_PATH=${DISK_BASE_PATH:="/global/cscratch1/sd/icecubed/jade-disk/lta"}
+export DISK_BASE_PATH=${DISK_BASE_PATH:="/pscratch/sd/i/icecubed"}
 # export INPUT_STATUS=${INPUT_STATUS:="detached"}
 export INPUT_STATUS=${INPUT_STATUS:="completed"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}

--- a/bin/gridftp-replicator.sh
+++ b/bin/gridftp-replicator.sh
@@ -8,8 +8,7 @@ export GLOBUS_PROXY_DURATION=${GLOBUS_PROXY_DURATION:="72"}
 #export GLOBUS_PROXY_PASSPHRASE=${GLOBUS_PROXY_PASSPHRASE:="hunter2"}  # http://bash.org/?244321
 #export GLOBUS_PROXY_VOMS_ROLE=${GLOBUS_PROXY_VOMS_ROLE:=""}
 #export GLOBUS_PROXY_VOMS_VO=${GLOBUS_PROXY_VOMS_VO:=""}
-#export GRIDFTP_DEST_URL=${GRIDFTP_DEST_URL:="gsiftp://dtn05.nersc.gov:2811/global/cscratch1/sd/icecubed/jade-disk/lta"}
-export GRIDFTP_DEST_URLS=${GRIDFTP_DEST_URLS:="gsiftp://dtn01.nersc.gov:2811/global/cscratch1/sd/icecubed/jade-disk/lta;gsiftp://dtn02.nersc.gov:2811/global/cscratch1/sd/icecubed/jade-disk/lta;gsiftp://dtn03.nersc.gov:2811/global/cscratch1/sd/icecubed/jade-disk/lta;gsiftp://dtn04.nersc.gov:2811/global/cscratch1/sd/icecubed/jade-disk/lta"}
+export GRIDFTP_DEST_URLS=${GRIDFTP_DEST_URLS:="gsiftp://dtn01.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn02.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn03.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn04.nersc.gov:2811/pscratch/sd/i/icecubed"}
 export GRIDFTP_TIMEOUT=${GRIDFTP_TIMEOUT:="43200"}  # 43200 sec = 12 hours
 export INPUT_STATUS=${INPUT_STATUS:="staged"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}

--- a/bin/nersc-retriever.sh
+++ b/bin/nersc-retriever.sh
@@ -13,7 +13,7 @@ export LTA_REST_URL=${LTA_REST_URL:="https://lta.icecube.aq:443"}
 # export OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:="https://telemetry.dev.icecube.aq/v1/traces"}
 export OUTPUT_STATUS=${OUTPUT_STATUS:="staged"}
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="python"
-export RSE_BASE_PATH=${RSE_BASE_PATH:="/global/cscratch1/sd/icecubed/jade-disk/lta"}
+export RSE_BASE_PATH=${RSE_BASE_PATH:="/pscratch/sd/i/icecubed"}
 export RUN_ONCE_AND_DIE=${RUN_ONCE_AND_DIE:="True"}
 export RUN_UNTIL_NO_WORK=${RUN_UNTIL_NO_WORK:="FALSE"}
 export SOURCE_SITE=${SOURCE_SITE:="NERSC"}

--- a/bin/pipe0-gridftp-replicator.sh
+++ b/bin/pipe0-gridftp-replicator.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
-# deftarget="1"
-# if [[  "$1" != "" ]]
-#   then
-#     if [[ "$1" == "2" || "$1" == "3" || "$1" == "4" ]]
-#       then
-#         deftarget="$1"
-#       fi
-#   fi
 export CLIENT_ID=${CLIENT_ID:="long-term-archive"}
 export CLIENT_SECRET=${CLIENT_SECRET:="$(<keycloak-client-secret)"}
 export COMPONENT_NAME=${COMPONENT_NAME:="$(hostname)-gridftp-replicator"}
@@ -16,8 +8,7 @@ export GLOBUS_PROXY_DURATION=${GLOBUS_PROXY_DURATION:="72"}
 #export GLOBUS_PROXY_PASSPHRASE=${GLOBUS_PROXY_PASSPHRASE:="hunter2"}  # http://bash.org/?244321
 #export GLOBUS_PROXY_VOMS_ROLE=${GLOBUS_PROXY_VOMS_ROLE:=""}
 #export GLOBUS_PROXY_VOMS_VO=${GLOBUS_PROXY_VOMS_VO:=""}
-# export GRIDFTP_DEST_URL=${GRIDFTP_DEST_URL:="gsiftp://dtn0${deftarget}.nersc.gov:2811/global/cscratch1/sd/icecubed/jade-disk/lta"}
-export GRIDFTP_DEST_URLS=${GRIDFTP_DEST_URLS:="gsiftp://dtn01.nersc.gov:2811/global/cscratch1/sd/icecubed/jade-disk/lta;gsiftp://dtn02.nersc.gov:2811/global/cscratch1/sd/icecubed/jade-disk/lta;gsiftp://dtn03.nersc.gov:2811/global/cscratch1/sd/icecubed/jade-disk/lta;gsiftp://dtn04.nersc.gov:2811/global/cscratch1/sd/icecubed/jade-disk/lta"}
+export GRIDFTP_DEST_URLS=${GRIDFTP_DEST_URLS:="gsiftp://dtn01.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn02.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn03.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn04.nersc.gov:2811/pscratch/sd/i/icecubed"}
 export GRIDFTP_TIMEOUT=${GRIDFTP_TIMEOUT:="43200"}  # 43200 sec = 12 hours
 export INPUT_STATUS=${INPUT_STATUS:="staged"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}

--- a/bin/pipe0-nersc-deleter.sh
+++ b/bin/pipe0-nersc-deleter.sh
@@ -5,7 +5,7 @@ export CLIENT_ID=${CLIENT_ID:="long-term-archive"}
 export CLIENT_SECRET=${CLIENT_SECRET:="$(<keycloak-client-secret)"}
 export COMPONENT_NAME=${COMPONENT_NAME:="$(hostname)-pipe0-nersc-deleter"}
 export DEST_SITE=${DEST_SITE:="NERSC"}
-export DISK_BASE_PATH=${DISK_BASE_PATH:="/global/cscratch1/sd/icecubed/jade-disk/lta"}
+export DISK_BASE_PATH=${DISK_BASE_PATH:="/pscratch/sd/i/icecubed"}
 export INPUT_STATUS=${INPUT_STATUS:="source-deleted"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}
 export LTA_AUTH_OPENID_URL=${LTA_AUTH_OPENID_URL:="https://keycloak.icecube.wisc.edu/auth/realms/IceCube"}

--- a/bin/pipe0-nersc-mover.sh
+++ b/bin/pipe0-nersc-mover.sh
@@ -12,7 +12,7 @@ export LTA_REST_URL=${LTA_REST_URL:="https://lta.icecube.aq:443"}
 export MAX_COUNT=${MAX_COUNT:="2"}
 # export OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:="https://telemetry.dev.icecube.aq/v1/traces"}
 export OUTPUT_STATUS=${OUTPUT_STATUS:="verifying"}
-export RSE_BASE_PATH=${RSE_BASE_PATH:="/global/cscratch1/sd/icecubed/jade-disk/lta"}
+export RSE_BASE_PATH=${RSE_BASE_PATH:="/pscratch/sd/i/icecubed"}
 export RUN_ONCE_AND_DIE=${RUN_ONCE_AND_DIE:="FALSE"}
 export RUN_UNTIL_NO_WORK=${RUN_UNTIL_NO_WORK:="TRUE"}
 export SOURCE_SITE=${SOURCE_SITE:="WIPAC"}

--- a/bin/pipe0-site-move-verifier.sh
+++ b/bin/pipe0-site-move-verifier.sh
@@ -4,7 +4,7 @@ source env/bin/activate
 export CLIENT_ID=${CLIENT_ID:="long-term-archive"}
 export CLIENT_SECRET=${CLIENT_SECRET:="$(<keycloak-client-secret)"}
 export COMPONENT_NAME=${COMPONENT_NAME:="$(hostname)-pipe0-site-move-verifier"}
-export DEST_ROOT_PATH=${DEST_ROOT_PATH:="/global/cscratch1/sd/icecubed/jade-disk/lta"}
+export DEST_ROOT_PATH=${DEST_ROOT_PATH:="/pscratch/sd/i/icecubed"}
 export DEST_SITE=${DEST_SITE:="NERSC"}
 export INPUT_STATUS=${INPUT_STATUS:="transferring"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}


### PR DESCRIPTION
NERSC is retiring the Cori system, including the Cori Scratch file system that lived at `/global/cscratch1/sd/icecubed`

This has been replaced by Perlmutter Scratch:
https://docs.nersc.gov/filesystems/perlmutter-scratch/

And according to NERSC, this currently lives at:
```
icecubed@perlmutter:login05:~> echo $PSCRATCH
/pscratch/sd/i/icecubed
```

This updates the configuration of LTA scripts to reflect the new scratch space.