### PR TITLE
Update LTA configuration to use Community File System instead of Perlmutter Scratch

### DIFF
--- a/bin/deleter-nersc-return.sh
+++ b/bin/deleter-nersc-return.sh
@@ -7,7 +7,7 @@ export CLIENT_ID=${CLIENT_ID:="long-term-archive"}
 export CLIENT_SECRET=${CLIENT_SECRET:="$(<keycloak-client-secret)"}
 export COMPONENT_NAME=${COMPONENT_NAME:="$(hostname)-deleter-return"}
 export DEST_SITE=${DEST_SITE:="WIPAC"}
-export DISK_BASE_PATH=${DISK_BASE_PATH:="/pscratch/sd/i/icecubed"}
+export DISK_BASE_PATH=${DISK_BASE_PATH:="/global/cfs/cdirs/icecubed"}
 # export INPUT_STATUS=${INPUT_STATUS:="detached"}
 export INPUT_STATUS=${INPUT_STATUS:="completed"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}

--- a/bin/gridftp-replicator.sh
+++ b/bin/gridftp-replicator.sh
@@ -8,7 +8,7 @@ export GLOBUS_PROXY_DURATION=${GLOBUS_PROXY_DURATION:="72"}
 #export GLOBUS_PROXY_PASSPHRASE=${GLOBUS_PROXY_PASSPHRASE:="hunter2"}  # http://bash.org/?244321
 #export GLOBUS_PROXY_VOMS_ROLE=${GLOBUS_PROXY_VOMS_ROLE:=""}
 #export GLOBUS_PROXY_VOMS_VO=${GLOBUS_PROXY_VOMS_VO:=""}
-export GRIDFTP_DEST_URLS=${GRIDFTP_DEST_URLS:="gsiftp://dtn01.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn02.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn03.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn04.nersc.gov:2811/pscratch/sd/i/icecubed"}
+export GRIDFTP_DEST_URLS=${GRIDFTP_DEST_URLS:="gsiftp://dtn01.nersc.gov:2811/global/cfs/cdirs/icecubed;gsiftp://dtn02.nersc.gov:2811/global/cfs/cdirs/icecubed;gsiftp://dtn03.nersc.gov:2811/global/cfs/cdirs/icecubed;gsiftp://dtn04.nersc.gov:2811/global/cfs/cdirs/icecubed"}
 export GRIDFTP_TIMEOUT=${GRIDFTP_TIMEOUT:="43200"}  # 43200 sec = 12 hours
 export INPUT_STATUS=${INPUT_STATUS:="staged"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}

--- a/bin/nersc-retriever.sh
+++ b/bin/nersc-retriever.sh
@@ -13,7 +13,7 @@ export LTA_REST_URL=${LTA_REST_URL:="https://lta.icecube.aq:443"}
 # export OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:="https://telemetry.dev.icecube.aq/v1/traces"}
 export OUTPUT_STATUS=${OUTPUT_STATUS:="staged"}
 export PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION="python"
-export RSE_BASE_PATH=${RSE_BASE_PATH:="/pscratch/sd/i/icecubed"}
+export RSE_BASE_PATH=${RSE_BASE_PATH:="/global/cfs/cdirs/icecubed"}
 export RUN_ONCE_AND_DIE=${RUN_ONCE_AND_DIE:="True"}
 export RUN_UNTIL_NO_WORK=${RUN_UNTIL_NO_WORK:="FALSE"}
 export SOURCE_SITE=${SOURCE_SITE:="NERSC"}

--- a/bin/pipe0-gridftp-replicator.sh
+++ b/bin/pipe0-gridftp-replicator.sh
@@ -8,7 +8,7 @@ export GLOBUS_PROXY_DURATION=${GLOBUS_PROXY_DURATION:="72"}
 #export GLOBUS_PROXY_PASSPHRASE=${GLOBUS_PROXY_PASSPHRASE:="hunter2"}  # http://bash.org/?244321
 #export GLOBUS_PROXY_VOMS_ROLE=${GLOBUS_PROXY_VOMS_ROLE:=""}
 #export GLOBUS_PROXY_VOMS_VO=${GLOBUS_PROXY_VOMS_VO:=""}
-export GRIDFTP_DEST_URLS=${GRIDFTP_DEST_URLS:="gsiftp://dtn01.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn02.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn03.nersc.gov:2811/pscratch/sd/i/icecubed;gsiftp://dtn04.nersc.gov:2811/pscratch/sd/i/icecubed"}
+export GRIDFTP_DEST_URLS=${GRIDFTP_DEST_URLS:="gsiftp://dtn01.nersc.gov:2811/global/cfs/cdirs/icecubed;gsiftp://dtn02.nersc.gov:2811/global/cfs/cdirs/icecubed;gsiftp://dtn03.nersc.gov:2811/global/cfs/cdirs/icecubed;gsiftp://dtn04.nersc.gov:2811/global/cfs/cdirs/icecubed"}
 export GRIDFTP_TIMEOUT=${GRIDFTP_TIMEOUT:="43200"}  # 43200 sec = 12 hours
 export INPUT_STATUS=${INPUT_STATUS:="staged"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}

--- a/bin/pipe0-nersc-deleter.sh
+++ b/bin/pipe0-nersc-deleter.sh
@@ -5,7 +5,7 @@ export CLIENT_ID=${CLIENT_ID:="long-term-archive"}
 export CLIENT_SECRET=${CLIENT_SECRET:="$(<keycloak-client-secret)"}
 export COMPONENT_NAME=${COMPONENT_NAME:="$(hostname)-pipe0-nersc-deleter"}
 export DEST_SITE=${DEST_SITE:="NERSC"}
-export DISK_BASE_PATH=${DISK_BASE_PATH:="/pscratch/sd/i/icecubed"}
+export DISK_BASE_PATH=${DISK_BASE_PATH:="/global/cfs/cdirs/icecubed"}
 export INPUT_STATUS=${INPUT_STATUS:="source-deleted"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}
 export LTA_AUTH_OPENID_URL=${LTA_AUTH_OPENID_URL:="https://keycloak.icecube.wisc.edu/auth/realms/IceCube"}

--- a/bin/pipe0-nersc-mover.sh
+++ b/bin/pipe0-nersc-mover.sh
@@ -12,7 +12,7 @@ export LTA_REST_URL=${LTA_REST_URL:="https://lta.icecube.aq:443"}
 export MAX_COUNT=${MAX_COUNT:="2"}
 # export OTEL_EXPORTER_OTLP_ENDPOINT=${OTEL_EXPORTER_OTLP_ENDPOINT:="https://telemetry.dev.icecube.aq/v1/traces"}
 export OUTPUT_STATUS=${OUTPUT_STATUS:="verifying"}
-export RSE_BASE_PATH=${RSE_BASE_PATH:="/pscratch/sd/i/icecubed"}
+export RSE_BASE_PATH=${RSE_BASE_PATH:="/global/cfs/cdirs/icecubed"}
 export RUN_ONCE_AND_DIE=${RUN_ONCE_AND_DIE:="FALSE"}
 export RUN_UNTIL_NO_WORK=${RUN_UNTIL_NO_WORK:="TRUE"}
 export SOURCE_SITE=${SOURCE_SITE:="WIPAC"}

--- a/bin/pipe0-site-move-verifier.sh
+++ b/bin/pipe0-site-move-verifier.sh
@@ -4,7 +4,7 @@ source env/bin/activate
 export CLIENT_ID=${CLIENT_ID:="long-term-archive"}
 export CLIENT_SECRET=${CLIENT_SECRET:="$(<keycloak-client-secret)"}
 export COMPONENT_NAME=${COMPONENT_NAME:="$(hostname)-pipe0-site-move-verifier"}
-export DEST_ROOT_PATH=${DEST_ROOT_PATH:="/pscratch/sd/i/icecubed"}
+export DEST_ROOT_PATH=${DEST_ROOT_PATH:="/global/cfs/cdirs/icecubed"}
 export DEST_SITE=${DEST_SITE:="NERSC"}
 export INPUT_STATUS=${INPUT_STATUS:="transferring"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,7 +35,9 @@ crayons==0.4.0
 cryptography==40.0.2
     # via pyjwt
 deprecated==1.2.13
-    # via opentelemetry-api
+    # via
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-http
 dnspython==2.3.0
     # via pymongo
 exceptiongroup==1.1.1
@@ -48,7 +50,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.54.2
+grpcio==1.55.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -72,30 +74,34 @@ mypy==1.3.0
     # via lta (setup.py)
 mypy-extensions==1.0.0
     # via mypy
-opentelemetry-api==1.17.0
+opentelemetry-api==1.18.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   wipac-telemetry
-opentelemetry-exporter-jaeger==1.17.0
+opentelemetry-exporter-jaeger==1.18.0
     # via wipac-telemetry
-opentelemetry-exporter-jaeger-proto-grpc==1.17.0
+opentelemetry-exporter-jaeger-proto-grpc==1.18.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-jaeger-thrift==1.17.0
+opentelemetry-exporter-jaeger-thrift==1.18.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-http==1.17.0
-    # via wipac-telemetry
-opentelemetry-proto==1.17.0
+opentelemetry-exporter-otlp-proto-common==1.18.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.17.0
+opentelemetry-exporter-otlp-proto-http==1.18.0
+    # via wipac-telemetry
+opentelemetry-proto==1.18.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.18.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.38b0
+opentelemetry-semantic-conventions==0.39b0
     # via opentelemetry-sdk
 packaging==23.1
     # via pytest
@@ -139,7 +145,7 @@ pytest-mock==3.10.0
     # via lta (setup.py)
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.30.0
+requests==2.31.0
     # via
     #   lta (setup.py)
     #   opentelemetry-exporter-otlp-proto-http
@@ -167,11 +173,11 @@ tornado==6.3.2
     #   wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt
-types-requests==2.30.0.0
+types-requests==2.31.0.0
     # via lta (setup.py)
 types-urllib3==1.26.25.13
     # via types-requests
-typing-extensions==4.5.0
+typing-extensions==4.6.0
     # via
     #   mypy
     #   opentelemetry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,7 +23,9 @@ coloredlogs==15.0.1
 cryptography==40.0.2
     # via pyjwt
 deprecated==1.2.13
-    # via opentelemetry-api
+    # via
+    #   opentelemetry-api
+    #   opentelemetry-exporter-otlp-proto-http
 dnspython==2.3.0
     # via pymongo
 future==0.18.3
@@ -32,7 +34,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.54.2
+grpcio==1.55.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -44,30 +46,34 @@ importlib-metadata==6.0.1
     # via opentelemetry-api
 motor==3.1.2
     # via lta (setup.py)
-opentelemetry-api==1.17.0
+opentelemetry-api==1.18.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
     #   wipac-telemetry
-opentelemetry-exporter-jaeger==1.17.0
+opentelemetry-exporter-jaeger==1.18.0
     # via wipac-telemetry
-opentelemetry-exporter-jaeger-proto-grpc==1.17.0
+opentelemetry-exporter-jaeger-proto-grpc==1.18.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-jaeger-thrift==1.17.0
+opentelemetry-exporter-jaeger-thrift==1.18.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-http==1.17.0
-    # via wipac-telemetry
-opentelemetry-proto==1.17.0
+opentelemetry-exporter-otlp-proto-common==1.18.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.17.0
+opentelemetry-exporter-otlp-proto-http==1.18.0
+    # via wipac-telemetry
+opentelemetry-proto==1.18.0
+    # via
+    #   opentelemetry-exporter-otlp-proto-common
+    #   opentelemetry-exporter-otlp-proto-http
+opentelemetry-sdk==1.18.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.38b0
+opentelemetry-semantic-conventions==0.39b0
     # via opentelemetry-sdk
 prometheus-client==0.16.0
     # via lta (setup.py)
@@ -88,7 +94,7 @@ pypng==0.20220715.0
     # via qrcode
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.30.0
+requests==2.31.0
     # via
     #   opentelemetry-exporter-otlp-proto-http
     #   requests-futures
@@ -106,7 +112,7 @@ tornado==6.3.2
     #   wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt
-typing-extensions==4.5.0
+typing-extensions==4.6.0
     # via
     #   opentelemetry-sdk
     #   qrcode


### PR DESCRIPTION
Because Cori is being retired, #250 seemed like a natural fix.
However, Perlmutter Scratch (`pscratch`) isn't mounted on the Data Transfer Nodes (DTNs) the way Cori Scratch was.
So now we use the file system that both the DTNs and Perlmutter can see.
