### PR TITLE
Added scrontab job to clean Slurm logs

### DIFF
--- a/nersc/scrontab
+++ b/nersc/scrontab
@@ -1,6 +1,36 @@
+# Welcome to scrontab, Slurm's cron-like interface.
+#
+# Edit this file to submit recurring jobs to be run by Slurm.
+#
+# Note that jobs will be run based on the Slurm controller's
+# time and timezone.
+#
+# Lines must either be valid entries, comments (start with '#'),
+# or blank.
+#
+# Lines starting with #SCRON will be parsed for options to use
+# with the next cron line. E.g., "#SCRON --time 1" would request
+# a one minute timelimit be applied. See the sbatch man page for
+# options, although note that not all options are supported here.
+#
+# For example, the following line (when uncommented) would request
+# a job be run at 5am each day.
+# 0 5 * * * /my/script/to/run
+#
+# min hour day-of-month month day-of-week command
+
+# run LTA controller script every 10 minutes
 #SCRON -q cron
 #SCRON -A m1093
 #SCRON -t 00:30:00
 #SCRON -o /global/homes/i/icecubed/lta/scrontab-log.out
 #SCRON --open-mode=append
 */10 * * * * /global/homes/i/icecubed/lta/resources/nersc-controller.sh
+
+# every day at 2 AM, clean up two week old SLURM logs
+#SCRON -q cron
+#SCRON -A m1093
+#SCRON -t 00:15:00
+#SCRON -o /global/homes/i/icecubed/lta/slurm-clean.out
+#SCRON --open-mode=append
+0 2 * * * cd /global/homes/i/icecubed/lta/slurm-logs; find . -type f -mtime 14 -exec mv {} .. \;

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -28,7 +28,7 @@ colorama==0.4.6
     #   lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-coverage[toml]==7.2.5
+coverage[toml]==7.2.6
     # via pytest-cov
 crayons==0.4.0
     # via pycycle
@@ -50,7 +50,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.55.0
+grpcio==1.54.2
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -177,7 +177,7 @@ types-requests==2.31.0.0
     # via lta (setup.py)
 types-urllib3==1.26.25.13
     # via types-requests
-typing-extensions==4.6.0
+typing-extensions==4.6.1
     # via
     #   mypy
     #   opentelemetry-sdk
@@ -186,14 +186,14 @@ typing-extensions==4.6.0
     #   wipac-telemetry
 urllib3==2.0.2
     # via requests
-wipac-dev-tools==1.6.15
+wipac-dev-tools==1.6.16
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
 wipac-rest-tools==1.4.18
     # via lta (setup.py)
-wipac-telemetry==0.2.6
+wipac-telemetry==0.2.7
     # via lta (setup.py)
 wrapt==1.15.0
     # via deprecated

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,7 +34,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.55.0
+grpcio==1.54.2
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -112,7 +112,7 @@ tornado==6.3.2
     #   wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt
-typing-extensions==4.6.0
+typing-extensions==4.6.1
     # via
     #   opentelemetry-sdk
     #   qrcode
@@ -120,14 +120,14 @@ typing-extensions==4.6.0
     #   wipac-telemetry
 urllib3==2.0.2
     # via requests
-wipac-dev-tools==1.6.15
+wipac-dev-tools==1.6.16
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
 wipac-rest-tools==1.4.18
     # via lta (setup.py)
-wipac-telemetry==0.2.6
+wipac-telemetry==0.2.7
     # via lta (setup.py)
 wrapt==1.15.0
     # via deprecated


### PR DESCRIPTION
When we run LTA jobs, their output is logged. This is helpful for debugging, but mostly just noise.
If there is an error that we care about, we'll probably investigate within two weeks.
I've added a job that runs every day that deletes log files >14 days old.
