### PR TITLE
LTA should use the long-term-archive client secret

### DIFF
--- a/bin/pipe0-nersc-verifier.sh
+++ b/bin/pipe0-nersc-verifier.sh
@@ -5,8 +5,8 @@ export CLIENT_ID=${CLIENT_ID:="long-term-archive"}
 export CLIENT_SECRET=${CLIENT_SECRET:="$(<keycloak-client-secret)"}
 export COMPONENT_NAME=${COMPONENT_NAME:="$(hostname)-pipe0-nersc-verifier"}
 export DEST_SITE=${DEST_SITE:="NERSC"}
-export FILE_CATALOG_CLIENT_ID=${FILE_CATALOG_CLIENT_ID:="file-catalog"}
-export FILE_CATALOG_CLIENT_SECRET=${FILE_CATALOG_CLIENT_SECRET:="$(<file-catalog-client-secret)"}
+export FILE_CATALOG_CLIENT_ID=${FILE_CATALOG_CLIENT_ID:="long-term-archive"}
+export FILE_CATALOG_CLIENT_SECRET=${FILE_CATALOG_CLIENT_SECRET:="$(<keycloak-client-secret)"}
 export FILE_CATALOG_REST_URL=${FILE_CATALOG_REST_URL:="https://file-catalog.icecube.wisc.edu"}
 export HPSS_AVAIL_PATH=${HPSS_AVAIL_PATH:="/usr/bin/hpss_avail.py"}
 export INPUT_STATUS=${INPUT_STATUS:="verifying"}


### PR DESCRIPTION
LTA can access the File Catalog with its own client secret.
