### PR TITLE
nersc-verifier should use configured hpss_avail path

### DIFF
--- a/lta/nersc_verifier.py
+++ b/lta/nersc_verifier.py
@@ -95,7 +95,7 @@ class NerscVerifier(Component):
         """Claim a bundle and perform work on it."""
         # 0. Do some pre-flight checks to ensure that we can do work
         # if the HPSS system is not available
-        args = ["/usr/common/software/bin/hpss_avail", "archive"]
+        args = [self.hpss_avail_path, "archive"]
         completed_process = run(args, stdout=PIPE, stderr=PIPE)
         if completed_process.returncode != 0:
             # prevent this instance from claiming any work

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -139,7 +139,7 @@ pytest==7.3.1
     #   pytest-mock
 pytest-asyncio==0.21.0
     # via lta (setup.py)
-pytest-cov==4.0.0
+pytest-cov==4.1.0
     # via lta (setup.py)
 pytest-mock==3.10.0
     # via lta (setup.py)


### PR DESCRIPTION
Yeah, this should have been covered in #254 but it looks like nersc-verifier is still using the hard coded path :facepalm: 
