### PR TITLE
Request minimum and maximum time for slurm jobs at NERSC

### DIFF
--- a/nersc/scrontab
+++ b/nersc/scrontab
@@ -27,10 +27,10 @@
 #SCRON --open-mode=append
 */10 * * * * /global/homes/i/icecubed/lta/resources/nersc-controller.sh
 
-# every day at 2 AM, clean up two week old SLURM logs
+# every day at 2 AM, clean up week old SLURM logs
 #SCRON -q cron
 #SCRON -A m1093
 #SCRON -t 00:15:00
 #SCRON -o /global/homes/i/icecubed/lta/slurm-clean.out
 #SCRON --open-mode=append
-0 2 * * * cd /global/homes/i/icecubed/lta/slurm-logs; find . -type f -mtime 14 -exec mv {} .. \;
+0 2 * * * cd /global/homes/i/icecubed/lta/slurm-logs; find . -type f -mtime 7 -delete

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -107,7 +107,7 @@ packaging==23.1
     # via pytest
 pluggy==1.0.0
     # via pytest
-prometheus-client==0.16.0
+prometheus-client==0.17.0
     # via lta (setup.py)
 protobuf==3.20.3
     # via
@@ -177,7 +177,7 @@ types-requests==2.31.0.0
     # via lta (setup.py)
 types-urllib3==1.26.25.13
     # via types-requests
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   mypy
     #   opentelemetry-sdk
@@ -191,7 +191,7 @@ wipac-dev-tools==1.6.16
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.4.18
+wipac-rest-tools==1.4.19
     # via lta (setup.py)
 wipac-telemetry==0.2.7
     # via lta (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ opentelemetry-sdk==1.18.0
     #   wipac-telemetry
 opentelemetry-semantic-conventions==0.39b0
     # via opentelemetry-sdk
-prometheus-client==0.16.0
+prometheus-client==0.17.0
     # via lta (setup.py)
 protobuf==3.20.3
     # via
@@ -112,7 +112,7 @@ tornado==6.3.2
     #   wipac-rest-tools
 types-cryptography==3.3.23.2
     # via pyjwt
-typing-extensions==4.6.1
+typing-extensions==4.6.2
     # via
     #   opentelemetry-sdk
     #   qrcode
@@ -125,7 +125,7 @@ wipac-dev-tools==1.6.16
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.4.18
+wipac-rest-tools==1.4.19
     # via lta (setup.py)
 wipac-telemetry==0.2.7
     # via lta (setup.py)

--- a/resources/nersc-controller.sh
+++ b/resources/nersc-controller.sh
@@ -6,6 +6,8 @@ cd ${HOME}/lta
 source env/bin/activate
 
 # run the controller script
+export JOB_TIME=${JOB_TIME:="12:00:00"}
+export JOB_TIME_MIN=${JOB_TIME_MIN:="6:00:00"}
 export LOG_LEVEL=${LOG_LEVEL:="DEBUG"}
 export LOG_PATH=${LOG_PATH:="${HOME}/lta/nersc_controller.log"}
 export LTA_BIN_DIR=${LTA_BIN_DIR:="${HOME}/lta/bin"}


### PR DESCRIPTION
NERSC is 7 hours behind UTC:
```
icecubed@perlmutter:login07:~/lta/slurm-logs> date --utc
Fri 26 May 2023 10:38:12 PM UTC
icecubed@perlmutter:login07:~/lta/slurm-logs> date
Fri 26 May 2023 03:38:24 PM PDT
```

When running a nersc-mover (the LTA component that puts zip bundles on tape in HPSS), we started at 14:31 (local time) and the job is killed at 21:41 (utc time) --> 14:41 (local time):
```
2023-05-26 14:31:14,323 [MainThread] INFO  (component.py:93) - nersc_mover 'login28-pipe0-nersc-mover' is configured:
...
slurmstepd: error: *** JOB 9608169 ON login28 CANCELLED AT 2023-05-26T21:41:22 DUE TO TIME LIMIT ***
```

This means our job was cancelled after 10 minutes. This is not going to work for processes that can take a long time, like running a checksum on 100GB or copying 100GB into the HPSS tape system.

Moreover, it's difficult because the LTA doesn't get a chance to clean up. A claimed bundle isn't returned to the queue of unclaimed work. It sits claimed (so no other components will work on it) but is not processed. We don't detect this kind of error until 'Hey, why hasn't there been any progress on bundle X?'

So this PR introduces the `--time` and `--time-min` flags to our call to `sbatch`. By default it requests a 6 hour minimum run time and a 12 hour maximum run time. While it's unlikely that a single bundle could require 6 hours, it's possible that a single component could live for a long time if it continuously finds work to do.

It may be necessary to make components smart enough to know how long they've been alive, and make a configurable lifetime, so the component stops processing when it gets too close to the limit. We'll see how it goes, and if this is necessary in practice.