### PR TITLE
Bundler removes broken files of previous attempts

### DIFF
--- a/lta/bundler.py
+++ b/lta/bundler.py
@@ -5,6 +5,7 @@ import asyncio
 import json
 import logging
 import os
+from pathlib import Path
 import shutil
 import sys
 from typing import Any, Dict, Optional
@@ -177,6 +178,9 @@ class Bundler(Component):
                                      bundle_file_path: str,
                                      metadata_file_path: str,
                                      file_count: int) -> None:
+        # 0. Remove an existing bundle, if we are re-trying
+        Path(bundle_file_path).unlink(missing_ok=True)
+
         # 2. Create a ZIP bundle by writing constituent files to it
         bundle_uuid = bundle["uuid"]
         request_path = bundle["path"]
@@ -224,6 +228,9 @@ class Bundler(Component):
                                     bundle: BundleType,
                                     metadata_file_path: str,
                                     file_count: int) -> None:
+        # 0. Remove an existing manifest, if we are re-trying
+        Path(metadata_file_path).unlink(missing_ok=True)
+
         # 1. Create a manifest of the bundle, including all metadata
         bundle_uuid = bundle["uuid"]
         self.logger.info(f"Bundle metadata file will be created at: {metadata_file_path}")

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -32,7 +32,7 @@ coverage[toml]==7.2.7
     # via pytest-cov
 crayons==0.4.0
     # via pycycle
-cryptography==40.0.2
+cryptography==41.0.1
     # via pyjwt
 deprecated==1.2.14
     # via
@@ -64,7 +64,7 @@ iniconfig==2.0.0
     # via pytest
 jinja2==3.1.2
     # via click-completion
-markupsafe==2.1.2
+markupsafe==2.1.3
     # via jinja2
 mccabe==0.7.0
     # via flake8
@@ -175,7 +175,7 @@ types-requests==2.31.0.1
     # via lta (setup.py)
 types-urllib3==1.26.25.13
     # via types-requests
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   mypy
     #   opentelemetry-sdk

--- a/requirements.txt
+++ b/requirements.txt
@@ -20,7 +20,7 @@ colorama==0.4.6
     # via lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==40.0.2
+cryptography==41.0.1
     # via pyjwt
 deprecated==1.2.14
     # via
@@ -110,7 +110,7 @@ tornado==6.3.2
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
-typing-extensions==4.6.2
+typing-extensions==4.6.3
     # via
     #   opentelemetry-sdk
     #   qrcode


### PR DESCRIPTION
In practice, one of the trickiest bits of automatically recovering quarantined bundles is that the broken files (metadata and zip bundle) still exist on the disk.

When the next attempt comes along, it will fail again, as it refuses to overwrite existing files.

Cleaning these up in case of exception would be nice, but we can't guarantee the process won't be killed (i.e. kubernetes destroys the pod) so we have to handle the 'broken files left in the work directory' case no matter what.

An external cleaner runs into two issues:
- One, how do I know when I can remove the files? Did the process die, or is it just taking a long time?
- Two, permissions; getting the permissions of the cleaner to match the permissions of the bundler isn't always easy.

So the straightforward solution is: Delete any existing metadata and zip bundle files by the names that we intend to create.

Since they contain a UUID, it is very unlikely that the file would exist by that name unless we were the one to create it.
As part of the Bundler process, we already have the proper permissions to delete the files if they exist.
If the files do exist, we are removing broken files we aren't going to use; ready to create without conflicts.
If the files don't exist, no harm, no foul.

This should make it easier to restart LTA bundles that failed in the bundler step.
