### PR TITLE
Update scrontab for prune slurm logs

### DIFF
--- a/nersc/scrontab
+++ b/nersc/scrontab
@@ -33,4 +33,4 @@
 #SCRON -t 00:15:00
 #SCRON -o /global/homes/i/icecubed/lta/slurm-clean.out
 #SCRON --open-mode=append
-0 2 * * * cd /global/homes/i/icecubed/lta/slurm-logs; find . -type f -mtime 7 -delete
+0 2 * * * find /global/homes/i/icecubed/lta/slurm-logs -type f -mtime +7 -delete

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,9 +14,9 @@ cachetools==5.3.1
     # via wipac-rest-tools
 certifi==2023.7.22
     # via requests
-cffi==1.15.1
+cffi==1.16.0
     # via cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via requests
 click==8.1.7
     # via
@@ -30,7 +30,7 @@ colorama==0.4.6
     #   lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-coverage[toml]==7.3.1
+coverage[toml]==7.3.2
     # via pytest-cov
 crayons==0.4.0
     # via pycycle
@@ -52,7 +52,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.58.0
+grpcio==1.59.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -105,7 +105,7 @@ opentelemetry-sdk==1.20.0
     #   wipac-telemetry
 opentelemetry-semantic-conventions==0.41b0
     # via opentelemetry-sdk
-packaging==23.1
+packaging==23.2
     # via pytest
 pluggy==1.3.0
     # via pytest
@@ -173,10 +173,8 @@ tornado==6.3.3
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
-types-requests==2.31.0.6
+types-requests==2.31.0.7
     # via lta (setup.py)
-types-urllib3==1.26.25.14
-    # via types-requests
 typing-extensions==4.8.0
     # via
     #   mypy
@@ -184,18 +182,19 @@ typing-extensions==4.8.0
     #   qrcode
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==2.0.5
+urllib3==2.0.6
     # via
     #   requests
+    #   types-requests
     #   wipac-rest-tools
-wipac-dev-tools==1.6.16
+wipac-dev-tools==1.7.0
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
 wipac-rest-tools==1.5.3
     # via lta (setup.py)
-wipac-telemetry==0.2.7
+wipac-telemetry==0.3.0
     # via lta (setup.py)
 wrapt==1.15.0
     # via deprecated

--- a/requirements-monitoring.txt
+++ b/requirements-monitoring.txt
@@ -24,9 +24,9 @@ certifi==2023.7.22
     # via
     #   elasticsearch
     #   requests
-cffi==1.15.1
+cffi==1.16.0
     # via cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via
     #   aiohttp
     #   requests
@@ -54,7 +54,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.58.0
+grpcio==1.59.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -142,19 +142,19 @@ typing-extensions==4.8.0
     #   qrcode
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==2.0.5
+urllib3==2.0.6
     # via
     #   elasticsearch
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.6.16
+wipac-dev-tools==1.7.0
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
 wipac-rest-tools==1.5.3
     # via lta (setup.py)
-wipac-telemetry==0.2.7
+wipac-telemetry==0.3.0
     # via lta (setup.py)
 wrapt==1.15.0
     # via deprecated

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,9 +14,9 @@ cachetools==5.3.1
     # via wipac-rest-tools
 certifi==2023.7.22
     # via requests
-cffi==1.15.1
+cffi==1.16.0
     # via cryptography
-charset-normalizer==3.2.0
+charset-normalizer==3.3.0
     # via requests
 colorama==0.4.6
     # via lta (setup.py)
@@ -36,7 +36,7 @@ googleapis-common-protos==1.56.2
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.58.0
+grpcio==1.59.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -118,18 +118,18 @@ typing-extensions==4.8.0
     #   qrcode
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==2.0.5
+urllib3==2.0.6
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.6.16
+wipac-dev-tools==1.7.0
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
 wipac-rest-tools==1.5.3
     # via lta (setup.py)
-wipac-telemetry==0.2.7
+wipac-telemetry==0.3.0
     # via lta (setup.py)
 wrapt==1.15.0
     # via deprecated

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
 	wipac-dev-tools
 	wipac-rest-tools
 	wipac-telemetry
-python_requires = >=3.8, <3.12
+python_requires = >=3.8, <3.13
 packages = find:
 
 [options.extras_require]


### PR DESCRIPTION
`cd /global/homes/i/icecubed/lta/slurm-logs; find . -type f -mtime 7 -delete`

Not the most brilliant construction. If `/global/homes/i/icecubed/lta/slurm-logs` doesn't exist or is somehow inaccessible, it deletes things exactly a week old wherever scrontab jobs happen to start ... is that `${HOME}`? No idea.

Replaced with:
`find /global/homes/i/icecubed/lta/slurm-logs -type f -mtime +7 -delete`

This will find in the provided directory, or fail, and the `+7` means we get all the logs one week and older, not just those exactly a week old.