### PR TITLE
Fix Paths and Pins

### DIFF
--- a/collabssh
+++ b/collabssh
@@ -4,5 +4,5 @@
 # Use direct login to ssh to perlmutter with the icecubed collaboration account
 # See: https://docs.nersc.gov/accounts/collaboration_accounts/#direct-login
 
-sshproxy.sh -c icecubed
+./sshproxy.sh -c icecubed
 ssh -i ${HOME}/.ssh/icecubed icecubed@perlmutter-p1.nersc.gov

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
 	pymongo
 	tornado
 	wipac-dev-tools
-	wipac-rest-tools
+	wipac-rest-tools>=1.6
 	wipac-telemetry
 python_requires = >=3.9, <3.13
 packages = find:


### PR DESCRIPTION
* Modifies `collabssh` so that it invokes `sshproxy.sh` without requiring that the current directory be on one's PATH.
* Adds a lower bound on the `wipac-rest-tools` requirement; use of `ArgumentHandler` requires >=1.6.0
    * Pip was choosing from the 1.5.x series, which will no longer work.
