### PR TITLE
fix monitoring script syntax

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 binpacking==1.5.2
     # via lta (setup.py)
-cachetools==5.3.2
+cachetools==5.3.3
     # via wipac-rest-tools
 certifi==2024.2.2
     # via requests
@@ -26,7 +26,7 @@ colorama==0.4.6
     #   lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-coverage[toml]==7.4.3
+coverage[toml]==7.4.4
     # via pytest-cov
 crayons==0.4.0
     # via pycycle
@@ -38,7 +38,7 @@ deprecated==1.2.14
     #   opentelemetry-exporter-otlp-proto-http
 dnspython==2.6.1
     # via pymongo
-exceptiongroup==1.2.0
+exceptiongroup==1.2.1
     # via pytest
 flake8==7.0.0
     # via lta (setup.py)
@@ -48,15 +48,15 @@ googleapis-common-protos==1.59.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.62.0
+grpcio==1.62.2
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
 hurry-filesize==0.9
     # via lta (setup.py)
-idna==3.6
+idna==3.7
     # via requests
-importlib-metadata==6.11.0
+importlib-metadata==7.0.0
     # via opentelemetry-api
 iniconfig==2.0.0
     # via pytest
@@ -66,13 +66,13 @@ markupsafe==2.1.5
     # via jinja2
 mccabe==0.7.0
     # via flake8
-motor==3.3.2
+motor==3.4.0
     # via lta (setup.py)
-mypy==1.8.0
+mypy==1.9.0
     # via lta (setup.py)
 mypy-extensions==1.0.0
     # via mypy
-opentelemetry-api==1.23.0
+opentelemetry-api==1.24.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
@@ -85,25 +85,25 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.23.0
+opentelemetry-exporter-otlp-proto-common==1.24.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.23.0
+opentelemetry-exporter-otlp-proto-http==1.24.0
     # via wipac-telemetry
-opentelemetry-proto==1.23.0
+opentelemetry-proto==1.24.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.23.0
+opentelemetry-sdk==1.24.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.44b0
+opentelemetry-semantic-conventions==0.45b0
     # via opentelemetry-sdk
-packaging==23.2
+packaging==24.0
     # via pytest
-pluggy==1.4.0
+pluggy==1.5.0
     # via pytest
 prometheus-client==0.20.0
     # via lta (setup.py)
@@ -114,7 +114,7 @@ protobuf==4.25.3
     #   wipac-telemetry
 pycodestyle==2.11.1
     # via flake8
-pycparser==2.21
+pycparser==2.22
     # via cffi
 pycycle==0.0.8
     # via lta (setup.py)
@@ -122,24 +122,24 @@ pyflakes==3.2.0
     # via flake8
 pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
-pymongo==4.6.2
+pymongo==4.6.3
     # via
     #   lta (setup.py)
     #   motor
 pypng==0.20220715.0
     # via qrcode
-pytest==8.0.1
+pytest==8.1.1
     # via
     #   lta (setup.py)
     #   pycycle
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
-pytest-asyncio==0.23.5
+pytest-asyncio==0.23.6
     # via lta (setup.py)
-pytest-cov==4.1.0
+pytest-cov==5.0.0
     # via lta (setup.py)
-pytest-mock==3.12.0
+pytest-mock==3.14.0
     # via lta (setup.py)
 qrcode==7.4.2
     # via wipac-rest-tools
@@ -158,7 +158,7 @@ six==1.16.0
     # via
     #   click-completion
     #   thrift
-thrift==0.16.0
+thrift==0.20.0
     # via opentelemetry-exporter-jaeger-thrift
 tomli==2.0.1
     # via
@@ -169,11 +169,11 @@ tornado==6.4
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
-types-colorama==0.4.15.20240205
+types-colorama==0.4.15.20240311
     # via lta (setup.py)
-types-requests==2.31.0.20240218
+types-requests==2.31.0.20240406
     # via lta (setup.py)
-typing-extensions==4.9.0
+typing-extensions==4.11.0
     # via
     #   mypy
     #   opentelemetry-sdk
@@ -190,13 +190,13 @@ wipac-dev-tools==1.9.1
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.6.0
+wipac-rest-tools==1.7.1
     # via lta (setup.py)
 wipac-telemetry==0.3.0
     # via lta (setup.py)
 wrapt==1.16.0
     # via deprecated
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-monitoring.txt
+++ b/requirements-monitoring.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --extra=monitoring --output-file=requirements-monitoring.txt
 #
-aiohttp==3.9.3
+aiohttp==3.9.5
     # via elasticsearch
 aiosignal==1.3.1
     # via aiohttp
@@ -14,7 +14,7 @@ attrs==23.2.0
     # via aiohttp
 binpacking==1.5.2
     # via lta (setup.py)
-cachetools==5.3.2
+cachetools==5.3.3
     # via wipac-rest-tools
 certifi==2024.2.2
     # via
@@ -48,25 +48,25 @@ googleapis-common-protos==1.59.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.62.0
+grpcio==1.62.2
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
 hurry-filesize==0.9
     # via lta (setup.py)
-idna==3.6
+idna==3.7
     # via
     #   requests
     #   yarl
-importlib-metadata==6.11.0
+importlib-metadata==7.0.0
     # via opentelemetry-api
-motor==3.3.2
+motor==3.4.0
     # via lta (setup.py)
 multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.23.0
+opentelemetry-api==1.24.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
@@ -79,21 +79,21 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.23.0
+opentelemetry-exporter-otlp-proto-common==1.24.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.23.0
+opentelemetry-exporter-otlp-proto-http==1.24.0
     # via wipac-telemetry
-opentelemetry-proto==1.23.0
+opentelemetry-proto==1.24.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.23.0
+opentelemetry-sdk==1.24.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.44b0
+opentelemetry-semantic-conventions==0.45b0
     # via opentelemetry-sdk
 prometheus-client==0.20.0
     # via lta (setup.py)
@@ -102,11 +102,11 @@ protobuf==4.25.3
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   wipac-telemetry
-pycparser==2.21
+pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
-pymongo==4.6.2
+pymongo==4.6.3
     # via
     #   lta (setup.py)
     #   motor
@@ -124,13 +124,13 @@ requests-futures==1.0.1
     # via wipac-rest-tools
 six==1.16.0
     # via thrift
-thrift==0.16.0
+thrift==0.20.0
     # via opentelemetry-exporter-jaeger-thrift
 tornado==6.4
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
-typing-extensions==4.9.0
+typing-extensions==4.11.0
     # via
     #   opentelemetry-sdk
     #   qrcode
@@ -146,7 +146,7 @@ wipac-dev-tools==1.9.1
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.6.0
+wipac-rest-tools==1.7.1
     # via lta (setup.py)
 wipac-telemetry==0.3.0
     # via lta (setup.py)
@@ -156,7 +156,7 @@ yarl==1.9.4
     # via
     #   aiohttp
     #   elasticsearch
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 binpacking==1.5.2
     # via lta (setup.py)
-cachetools==5.3.2
+cachetools==5.3.3
     # via wipac-rest-tools
 certifi==2024.2.2
     # via requests
@@ -32,19 +32,19 @@ googleapis-common-protos==1.59.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.62.0
+grpcio==1.62.2
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
 hurry-filesize==0.9
     # via lta (setup.py)
-idna==3.6
+idna==3.7
     # via requests
-importlib-metadata==6.11.0
+importlib-metadata==7.0.0
     # via opentelemetry-api
-motor==3.3.2
+motor==3.4.0
     # via lta (setup.py)
-opentelemetry-api==1.23.0
+opentelemetry-api==1.24.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
@@ -57,21 +57,21 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.23.0
+opentelemetry-exporter-otlp-proto-common==1.24.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.23.0
+opentelemetry-exporter-otlp-proto-http==1.24.0
     # via wipac-telemetry
-opentelemetry-proto==1.23.0
+opentelemetry-proto==1.24.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.23.0
+opentelemetry-sdk==1.24.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.44b0
+opentelemetry-semantic-conventions==0.45b0
     # via opentelemetry-sdk
 prometheus-client==0.20.0
     # via lta (setup.py)
@@ -80,11 +80,11 @@ protobuf==4.25.3
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   wipac-telemetry
-pycparser==2.21
+pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
-pymongo==4.6.2
+pymongo==4.6.3
     # via
     #   lta (setup.py)
     #   motor
@@ -102,13 +102,13 @@ requests-futures==1.0.1
     # via wipac-rest-tools
 six==1.16.0
     # via thrift
-thrift==0.16.0
+thrift==0.20.0
     # via opentelemetry-exporter-jaeger-thrift
 tornado==6.4
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
-typing-extensions==4.9.0
+typing-extensions==4.11.0
     # via
     #   opentelemetry-sdk
     #   qrcode
@@ -123,13 +123,13 @@ wipac-dev-tools==1.9.1
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.6.0
+wipac-rest-tools==1.7.1
     # via lta (setup.py)
 wipac-telemetry==0.3.0
     # via lta (setup.py)
 wrapt==1.16.0
     # via deprecated
-zipp==3.17.0
+zipp==3.18.1
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/resources/progress_to_es.py
+++ b/resources/progress_to_es.py
@@ -87,7 +87,7 @@ class Collect:
             pprint(doc)
         else:
             try:
-                await self.es.index(index=self.index_name, id=catalog_file['uuid'], document=doc)
+                await self.es.index(self.index_name, doc, id=catalog_file['uuid'])
             except Exception:
                 pprint(doc)
                 pprint(catalog_file)

--- a/setupenv.sh
+++ b/setupenv.sh
@@ -4,4 +4,4 @@ virtualenv -p python3 env
 echo "unset PYTHONPATH" >> env/bin/activate
 . env/bin/activate
 pip install --upgrade pip
-pip install -r requirements.txt
+pip install -e .[dev,monitoring]


### PR DESCRIPTION
The syntax was written against a newer version of elasticsearch than we are using.  Go back to the older syntax.