### PR TITLE
Require rest-tools that supports leeway

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -190,7 +190,7 @@ wipac-dev-tools==1.9.1
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.7.1
+wipac-rest-tools==1.7.2
     # via lta (setup.py)
 wipac-telemetry==0.3.0
     # via lta (setup.py)

--- a/requirements-monitoring.txt
+++ b/requirements-monitoring.txt
@@ -146,7 +146,7 @@ wipac-dev-tools==1.9.1
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.7.1
+wipac-rest-tools==1.7.2
     # via lta (setup.py)
 wipac-telemetry==0.3.0
     # via lta (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -123,7 +123,7 @@ wipac-dev-tools==1.9.1
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.7.1
+wipac-rest-tools==1.7.2
     # via lta (setup.py)
 wipac-telemetry==0.3.0
     # via lta (setup.py)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,7 @@ install_requires =
 	pymongo
 	tornado
 	wipac-dev-tools
-	wipac-rest-tools>=1.6
+	wipac-rest-tools>=1.7.2
 	wipac-telemetry
 python_requires = >=3.9, <3.13
 packages = find:


### PR DESCRIPTION
David provided a PR (https://github.com/WIPACrepo/rest-tools/pull/142) that set a default leeway time for JWT auth in rest-tools.
This configuration change ensures that LTA makes use of this new leeway for authentication.
