### PR TITLE
Reduce Authentication Requests to Keycloak

### DIFF
--- a/lta/__init__.py
+++ b/lta/__init__.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function
 # is zero for an official release, positive for a development branch,
 # or negative for a release candidate or beta (after the base version
 # number has been incremented)
-__version__ = "0.41.34"
+__version__ = "0.42.0"
 version_info = (
     int(__version__.split(".")[0]),
     int(__version__.split(".")[1]),

--- a/lta/bundler.py
+++ b/lta/bundler.py
@@ -80,14 +80,14 @@ class Bundler(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -95,21 +95,9 @@ class Bundler(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 1. Ask the LTA DB for the next Bundle to be built
-        # configure a RestClient to talk to the File Catalog
-        fc_rc = ClientCredentialsAuth(address=self.file_catalog_rest_url,
-                                      token_url=self.lta_auth_openid_url,
-                                      client_id=self.file_catalog_client_id,
-                                      client_secret=self.file_catalog_client_secret)
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         self.logger.info("Asking the LTA DB for a Bundle to build.")
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"
@@ -120,6 +108,11 @@ class Bundler(Component):
         if not bundle:
             self.logger.info("LTA DB did not provide a Bundle to build. Going on vacation.")
             return False
+        # configure a RestClient to talk to the File Catalog
+        fc_rc = ClientCredentialsAuth(address=self.file_catalog_rest_url,
+                                      token_url=self.lta_auth_openid_url,
+                                      client_id=self.file_catalog_client_id,
+                                      client_secret=self.file_catalog_client_secret)
         # process the Bundle that we were given
         try:
             await self._do_work_bundle(fc_rc, lta_rc, bundle)

--- a/lta/desy_move_verifier.py
+++ b/lta/desy_move_verifier.py
@@ -8,7 +8,7 @@ import sys
 from typing import Any, Dict, Optional
 
 from prometheus_client import Counter, Gauge, start_http_server
-from rest_tools.client import ClientCredentialsAuth, RestClient
+from rest_tools.client import RestClient
 import wipac_telemetry.tracing_tools as wtt
 
 from .component import COMMON_CONFIG, Component, now, work_loop
@@ -70,14 +70,14 @@ class DesyMoveVerifier(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -85,16 +85,9 @@ class DesyMoveVerifier(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 1. Ask the LTA DB for the next Bundle to be verified
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         self.logger.info("Asking the LTA DB for a Bundle to verify.")
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"

--- a/lta/desy_verifier.py
+++ b/lta/desy_verifier.py
@@ -73,14 +73,14 @@ class DesyVerifier(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -88,17 +88,10 @@ class DesyVerifier(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 1. Ask the LTA DB for the next Bundle to be verified
         self.logger.info("Asking the LTA DB for a Bundle to record as verified at DESY.")
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"
         }

--- a/lta/gridftp_replicator.py
+++ b/lta/gridftp_replicator.py
@@ -9,7 +9,7 @@ import sys
 from typing import Any, Dict, Optional
 
 from prometheus_client import Counter, Gauge, start_http_server
-from rest_tools.client import ClientCredentialsAuth, RestClient
+from rest_tools.client import RestClient
 import wipac_telemetry.tracing_tools as wtt
 
 from .component import COMMON_CONFIG, Component, now, work_loop
@@ -82,14 +82,14 @@ class GridFTPReplicator(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -97,16 +97,9 @@ class GridFTPReplicator(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 1. Ask the LTA DB for the next Bundle to be transferred
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         self.logger.info("Asking the LTA DB for a Bundle to transfer.")
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"

--- a/lta/locator.py
+++ b/lta/locator.py
@@ -93,14 +93,14 @@ class Locator(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on TransferRequests.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -108,16 +108,9 @@ class Locator(Component):
         self.logger.info("Ending work on TransferRequests.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a transfer request and perform work on it."""
         # 1. Ask the LTA DB for the next TransferRequest to be picked
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         self.logger.info("Asking the LTA DB for a TransferRequest to work on.")
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"

--- a/lta/lta_cmd.py
+++ b/lta/lta_cmd.py
@@ -784,7 +784,7 @@ async def request_new(args: Namespace) -> ExitCode:
     dest = args.dest
     path = normalize_path(args.path)
     # if the request contains nothing at all, don't try to archive it
-    if (size == 0) or (len(disk_files) == 0):
+    if ((size == 0) or (len(disk_files) == 0)) and (args.force is False):
         raise Exception(f"TransferRequest for {path}\n{size:,} bytes ({hurry.filesize.size(size)}) in {len(disk_files):,} files.\nWill NOT attempt to archive 0 bytes.")
     # if it doesn't meet our minimize size requirement
     if size < MINIMUM_REQUEST_SIZE:

--- a/lta/nersc_mover.py
+++ b/lta/nersc_mover.py
@@ -9,7 +9,7 @@ import sys
 from typing import Any, Dict, List, Optional
 
 from prometheus_client import Counter, Gauge, start_http_server
-from rest_tools.client import ClientCredentialsAuth, RestClient
+from rest_tools.client import RestClient
 import wipac_telemetry.tracing_tools as wtt
 
 from .component import COMMON_CONFIG, Component, now, work_loop
@@ -80,14 +80,14 @@ class NerscMover(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -95,7 +95,7 @@ class NerscMover(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 0. Do some pre-flight checks to ensure that we can do work
         # if the HPSS system is not available
@@ -107,13 +107,6 @@ class NerscMover(Component):
             return False
         # 1. Ask the LTA DB for the next Bundle to be taped
         self.logger.info("Asking the LTA DB for a Bundle to tape at NERSC with HPSS.")
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"
         }

--- a/lta/nersc_retriever.py
+++ b/lta/nersc_retriever.py
@@ -9,7 +9,7 @@ import sys
 from typing import Any, Dict, List, Optional
 
 from prometheus_client import Counter, Gauge, start_http_server
-from rest_tools.client import ClientCredentialsAuth, RestClient
+from rest_tools.client import RestClient
 import wipac_telemetry.tracing_tools as wtt
 
 from .component import COMMON_CONFIG, Component, now, work_loop
@@ -78,14 +78,14 @@ class NerscRetriever(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -93,7 +93,7 @@ class NerscRetriever(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 0. Do some pre-flight checks to ensure that we can do work
         # if the HPSS system is not available
@@ -105,13 +105,6 @@ class NerscRetriever(Component):
             return False
         # 1. Ask the LTA DB for the next Bundle to be taped
         self.logger.info("Asking the LTA DB for a Bundle copy from tape at NERSC with HPSS.")
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"
         }

--- a/lta/nersc_verifier.py
+++ b/lta/nersc_verifier.py
@@ -85,14 +85,14 @@ class NerscVerifier(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -100,7 +100,7 @@ class NerscVerifier(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 0. Do some pre-flight checks to ensure that we can do work
         # if the HPSS system is not available
@@ -112,13 +112,6 @@ class NerscVerifier(Component):
             return False
         # 1. Ask the LTA DB for the next Bundle to be verified
         self.logger.info("Asking the LTA DB for a Bundle to verify at NERSC with HPSS.")
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"
         }

--- a/lta/picker.py
+++ b/lta/picker.py
@@ -75,14 +75,14 @@ class Picker(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on TransferRequests.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -90,16 +90,9 @@ class Picker(Component):
         self.logger.info("Ending work on TransferRequests.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a transfer request and perform work on it."""
         # 1. Ask the LTA DB for the next TransferRequest to be picked
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         self.logger.info("Asking the LTA DB for a TransferRequest to work on.")
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"

--- a/lta/rate_limiter.py
+++ b/lta/rate_limiter.py
@@ -9,7 +9,7 @@ import sys
 from typing import Any, Dict, List, Optional, Tuple
 
 from prometheus_client import Counter, Gauge, start_http_server
-from rest_tools.client import ClientCredentialsAuth, RestClient
+from rest_tools.client import RestClient
 import wipac_telemetry.tracing_tools as wtt
 
 from .component import COMMON_CONFIG, Component, now, work_loop
@@ -98,14 +98,14 @@ class RateLimiter(Component):
         return (disk_files, size)
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -113,16 +113,9 @@ class RateLimiter(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 1. Ask the LTA DB for the next Bundle to be staged
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         self.logger.info("Asking the LTA DB for a Bundle to stage.")
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"

--- a/lta/site_move_verifier.py
+++ b/lta/site_move_verifier.py
@@ -9,7 +9,7 @@ import sys
 from typing import Any, Dict, List, Optional
 
 from prometheus_client import Counter, Gauge, start_http_server
-from rest_tools.client import ClientCredentialsAuth, RestClient
+from rest_tools.client import RestClient
 import wipac_telemetry.tracing_tools as wtt
 
 from .component import COMMON_CONFIG, Component, now, work_loop
@@ -108,14 +108,14 @@ class SiteMoveVerifier(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -123,16 +123,9 @@ class SiteMoveVerifier(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 1. Ask the LTA DB for the next Bundle to be verified
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         self.logger.info("Asking the LTA DB for a Bundle to verify.")
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"

--- a/lta/transfer_request_finisher.py
+++ b/lta/transfer_request_finisher.py
@@ -7,7 +7,7 @@ import sys
 from typing import Any, Dict, Optional, Union
 
 from prometheus_client import Counter, Gauge, start_http_server
-from rest_tools.client import ClientCredentialsAuth, RestClient
+from rest_tools.client import RestClient
 import wipac_telemetry.tracing_tools as wtt
 
 from .component import COMMON_CONFIG, Component, now, work_loop
@@ -62,14 +62,14 @@ class TransferRequestFinisher(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -77,16 +77,9 @@ class TransferRequestFinisher(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 1. Ask the LTA DB for the next Bundle to be deleted
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         self.logger.info("Asking the LTA DB for a Bundle to check for TransferRequest being finished.")
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"

--- a/lta/unpacker.py
+++ b/lta/unpacker.py
@@ -12,7 +12,7 @@ from typing import Any, cast, Dict, Optional
 from zipfile import ZipFile
 
 from prometheus_client import Counter, Gauge, start_http_server
-from rest_tools.client import ClientCredentialsAuth
+from rest_tools.client import ClientCredentialsAuth, RestClient
 import wipac_telemetry.tracing_tools as wtt
 
 from .component import COMMON_CONFIG, Component, now, work_loop
@@ -85,14 +85,14 @@ class Unpacker(Component):
         return EXPECTED_CONFIG
 
     @wtt.spanned()
-    async def _do_work(self) -> None:
+    async def _do_work(self, lta_rc: RestClient) -> None:
         """Perform a work cycle for this component."""
         self.logger.info("Starting work on Bundles.")
         load_level = -1
         work_claimed = True
         while work_claimed:
             load_level += 1
-            work_claimed = await self._do_work_claim()
+            work_claimed = await self._do_work_claim(lta_rc)
             # if we are configured to run once and die, then die
             if self.run_once_and_die:
                 sys.exit()
@@ -100,16 +100,9 @@ class Unpacker(Component):
         self.logger.info("Ending work on Bundles.")
 
     @wtt.spanned()
-    async def _do_work_claim(self) -> bool:
+    async def _do_work_claim(self, lta_rc: RestClient) -> bool:
         """Claim a bundle and perform work on it."""
         # 1. Ask the LTA DB for the next Bundle to be unpacked
-        # configure a RestClient to talk to the LTA DB
-        lta_rc = ClientCredentialsAuth(address=self.lta_rest_url,
-                                       token_url=self.lta_auth_openid_url,
-                                       client_id=self.client_id,
-                                       client_secret=self.client_secret,
-                                       timeout=self.work_timeout_seconds,
-                                       retries=self.work_retries)
         self.logger.info("Asking the LTA DB for a Bundle to unpack.")
         pop_body = {
             "claimant": f"{self.name}-{self.instance_uuid}"
@@ -132,7 +125,7 @@ class Unpacker(Component):
         return True
 
     @wtt.spanned()
-    async def _do_work_bundle(self, lta_rc: ClientCredentialsAuth, bundle: BundleType) -> None:
+    async def _do_work_bundle(self, lta_rc: RestClient, bundle: BundleType) -> None:
         """Unpack the bundle to the Data Warehouse and update the File Catalog and LTA DB."""
         # 0. Get our ducks in a row about what we're doing here
         bundle_file = os.path.basename(bundle["bundle_path"])
@@ -284,7 +277,7 @@ class Unpacker(Component):
 
     @wtt.spanned()
     async def _quarantine_bundle(self,
-                                 lta_rc: ClientCredentialsAuth,
+                                 lta_rc: RestClient,
                                  bundle: BundleType,
                                  reason: str) -> None:
         """Quarantine the supplied bundle using the supplied reason."""
@@ -347,7 +340,7 @@ class Unpacker(Component):
         return cast(Dict[str, Any], metadata_dict)
 
     @wtt.spanned()
-    async def _update_bundle_in_lta_db(self, lta_rc: ClientCredentialsAuth, bundle: BundleType) -> bool:
+    async def _update_bundle_in_lta_db(self, lta_rc: RestClient, bundle: BundleType) -> bool:
         """Update the LTA DB to indicate the Bundle is unpacked."""
         bundle_id = bundle["uuid"]
         patch_body = {

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ binpacking==1.5.2
     # via lta (setup.py)
 cachetools==5.3.3
     # via wipac-rest-tools
-certifi==2024.2.2
+certifi==2024.7.4
     # via requests
 cffi==1.16.0
     # via cryptography
@@ -26,11 +26,11 @@ colorama==0.4.6
     #   lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-coverage[toml]==7.4.4
+coverage[toml]==7.5.4
     # via pytest-cov
 crayons==0.4.0
     # via pycycle
-cryptography==42.0.5
+cryptography==42.0.8
     # via pyjwt
 deprecated==1.2.14
     # via
@@ -40,7 +40,7 @@ dnspython==2.6.1
     # via pymongo
 exceptiongroup==1.2.1
     # via pytest
-flake8==7.0.0
+flake8==7.1.0
     # via lta (setup.py)
 future==1.0.0
     # via binpacking
@@ -48,7 +48,7 @@ googleapis-common-protos==1.59.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.62.2
+grpcio==1.64.1
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -56,28 +56,29 @@ hurry-filesize==0.9
     # via lta (setup.py)
 idna==3.7
     # via requests
-importlib-metadata==7.0.0
+importlib-metadata==7.1.0
     # via opentelemetry-api
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.3
+jinja2==3.1.4
     # via click-completion
 markupsafe==2.1.5
     # via jinja2
 mccabe==0.7.0
     # via flake8
-motor==3.4.0
+motor==3.5.0
     # via lta (setup.py)
-mypy==1.9.0
+mypy==1.10.1
     # via lta (setup.py)
 mypy-extensions==1.0.0
     # via mypy
-opentelemetry-api==1.24.0
+opentelemetry-api==1.25.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   wipac-telemetry
 opentelemetry-exporter-jaeger==1.21.0
     # via wipac-telemetry
@@ -85,23 +86,23 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.24.0
+opentelemetry-exporter-otlp-proto-common==1.25.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.24.0
+opentelemetry-exporter-otlp-proto-http==1.25.0
     # via wipac-telemetry
-opentelemetry-proto==1.24.0
+opentelemetry-proto==1.25.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.24.0
+opentelemetry-sdk==1.25.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.45b0
+opentelemetry-semantic-conventions==0.46b0
     # via opentelemetry-sdk
-packaging==24.0
+packaging==24.1
     # via pytest
 pluggy==1.5.0
     # via pytest
@@ -112,7 +113,7 @@ protobuf==4.25.3
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   wipac-telemetry
-pycodestyle==2.11.1
+pycodestyle==2.12.0
     # via flake8
 pycparser==2.22
     # via cffi
@@ -122,20 +123,20 @@ pyflakes==3.2.0
     # via flake8
 pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
-pymongo==4.6.3
+pymongo==4.8.0
     # via
     #   lta (setup.py)
     #   motor
 pypng==0.20220715.0
     # via qrcode
-pytest==8.1.1
+pytest==8.2.2
     # via
     #   lta (setup.py)
     #   pycycle
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
-pytest-asyncio==0.23.6
+pytest-asyncio==0.23.7
     # via lta (setup.py)
 pytest-cov==5.0.0
     # via lta (setup.py)
@@ -143,7 +144,7 @@ pytest-mock==3.14.0
     # via lta (setup.py)
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.31.0
+requests==2.32.3
     # via
     #   lta (setup.py)
     #   opentelemetry-exporter-otlp-proto-http
@@ -165,38 +166,38 @@ tomli==2.0.1
     #   coverage
     #   mypy
     #   pytest
-tornado==6.4
+tornado==6.4.1
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
 types-colorama==0.4.15.20240311
     # via lta (setup.py)
-types-requests==2.31.0.20240406
+types-requests==2.32.0.20240622
     # via lta (setup.py)
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   mypy
     #   opentelemetry-sdk
     #   qrcode
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   requests
     #   types-requests
     #   wipac-rest-tools
-wipac-dev-tools==1.9.1
+wipac-dev-tools==1.10.6
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.7.2
+wipac-rest-tools==1.7.6
     # via lta (setup.py)
 wipac-telemetry==0.3.0
     # via lta (setup.py)
 wrapt==1.16.0
     # via deprecated
-zipp==3.18.1
+zipp==3.19.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements-monitoring.txt
+++ b/requirements-monitoring.txt
@@ -16,7 +16,7 @@ binpacking==1.5.2
     # via lta (setup.py)
 cachetools==5.3.3
     # via wipac-rest-tools
-certifi==2024.2.2
+certifi==2024.7.4
     # via
     #   elasticsearch
     #   requests
@@ -28,7 +28,7 @@ colorama==0.4.6
     # via lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==42.0.5
+cryptography==42.0.8
     # via pyjwt
 deprecated==1.2.14
     # via
@@ -48,7 +48,7 @@ googleapis-common-protos==1.59.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.62.2
+grpcio==1.64.1
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -58,20 +58,21 @@ idna==3.7
     # via
     #   requests
     #   yarl
-importlib-metadata==7.0.0
+importlib-metadata==7.1.0
     # via opentelemetry-api
-motor==3.4.0
+motor==3.5.0
     # via lta (setup.py)
 multidict==6.0.5
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.24.0
+opentelemetry-api==1.25.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   wipac-telemetry
 opentelemetry-exporter-jaeger==1.21.0
     # via wipac-telemetry
@@ -79,21 +80,21 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.24.0
+opentelemetry-exporter-otlp-proto-common==1.25.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.24.0
+opentelemetry-exporter-otlp-proto-http==1.25.0
     # via wipac-telemetry
-opentelemetry-proto==1.24.0
+opentelemetry-proto==1.25.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.24.0
+opentelemetry-sdk==1.25.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.45b0
+opentelemetry-semantic-conventions==0.46b0
     # via opentelemetry-sdk
 prometheus-client==0.20.0
     # via lta (setup.py)
@@ -106,7 +107,7 @@ pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
-pymongo==4.6.3
+pymongo==4.8.0
     # via
     #   lta (setup.py)
     #   motor
@@ -114,7 +115,7 @@ pypng==0.20220715.0
     # via qrcode
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.31.0
+requests==2.32.3
     # via
     #   opentelemetry-exporter-otlp-proto-http
     #   requests-futures
@@ -126,27 +127,27 @@ six==1.16.0
     # via thrift
 thrift==0.20.0
     # via opentelemetry-exporter-jaeger-thrift
-tornado==6.4
+tornado==6.4.1
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   opentelemetry-sdk
     #   qrcode
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   elasticsearch
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.9.1
+wipac-dev-tools==1.10.6
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.7.2
+wipac-rest-tools==1.7.6
     # via lta (setup.py)
 wipac-telemetry==0.3.0
     # via lta (setup.py)
@@ -156,7 +157,7 @@ yarl==1.9.4
     # via
     #   aiohttp
     #   elasticsearch
-zipp==3.18.1
+zipp==3.19.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ binpacking==1.5.2
     # via lta (setup.py)
 cachetools==5.3.3
     # via wipac-rest-tools
-certifi==2024.2.2
+certifi==2024.7.4
     # via requests
 cffi==1.16.0
     # via cryptography
@@ -18,7 +18,7 @@ colorama==0.4.6
     # via lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==42.0.5
+cryptography==42.0.8
     # via pyjwt
 deprecated==1.2.14
     # via
@@ -32,7 +32,7 @@ googleapis-common-protos==1.59.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.62.2
+grpcio==1.64.1
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -40,16 +40,17 @@ hurry-filesize==0.9
     # via lta (setup.py)
 idna==3.7
     # via requests
-importlib-metadata==7.0.0
+importlib-metadata==7.1.0
     # via opentelemetry-api
-motor==3.4.0
+motor==3.5.0
     # via lta (setup.py)
-opentelemetry-api==1.24.0
+opentelemetry-api==1.25.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   opentelemetry-sdk
+    #   opentelemetry-semantic-conventions
     #   wipac-telemetry
 opentelemetry-exporter-jaeger==1.21.0
     # via wipac-telemetry
@@ -57,21 +58,21 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.24.0
+opentelemetry-exporter-otlp-proto-common==1.25.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.24.0
+opentelemetry-exporter-otlp-proto-http==1.25.0
     # via wipac-telemetry
-opentelemetry-proto==1.24.0
+opentelemetry-proto==1.25.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.24.0
+opentelemetry-sdk==1.25.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.45b0
+opentelemetry-semantic-conventions==0.46b0
     # via opentelemetry-sdk
 prometheus-client==0.20.0
     # via lta (setup.py)
@@ -84,7 +85,7 @@ pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.8.0
     # via wipac-rest-tools
-pymongo==4.6.3
+pymongo==4.8.0
     # via
     #   lta (setup.py)
     #   motor
@@ -92,7 +93,7 @@ pypng==0.20220715.0
     # via qrcode
 qrcode==7.4.2
     # via wipac-rest-tools
-requests==2.31.0
+requests==2.32.3
     # via
     #   opentelemetry-exporter-otlp-proto-http
     #   requests-futures
@@ -104,32 +105,32 @@ six==1.16.0
     # via thrift
 thrift==0.20.0
     # via opentelemetry-exporter-jaeger-thrift
-tornado==6.4
+tornado==6.4.1
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
-typing-extensions==4.11.0
+typing-extensions==4.12.2
     # via
     #   opentelemetry-sdk
     #   qrcode
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.9.1
+wipac-dev-tools==1.10.6
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.7.2
+wipac-rest-tools==1.7.6
     # via lta (setup.py)
 wipac-telemetry==0.3.0
     # via lta (setup.py)
 wrapt==1.16.0
     # via deprecated
-zipp==3.18.1
+zipp==3.19.2
     # via importlib-metadata
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setupenv.sh
+++ b/setupenv.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 unset PYTHONPATH
-virtualenv -p python3 env
+# virtualenv -p python3 env
+python3 -m venv env
 echo "unset PYTHONPATH" >> env/bin/activate
 . env/bin/activate
 pip install --upgrade pip

--- a/tests/test_desy_move_verifier.py
+++ b/tests/test_desy_move_verifier.py
@@ -177,22 +177,24 @@ async def test_desy_move_verifier_run_exception(config: TestConfig, mocker: Mock
 async def test_desy_move_verifier_do_work_pop_exception(config: TestConfig, mocker: MockerFixture) -> None:
     """Test that _do_work raises when the RestClient can't pop."""
     logger_mock = mocker.MagicMock()
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = HTTPError(500, "LTA DB on fire. Again.")
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.side_effect = HTTPError(500, "LTA DB on fire. Again.")
     p = DesyMoveVerifier(config, logger_mock)
     with pytest.raises(HTTPError):
-        await p._do_work()
-    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=DESY&status=transferring', {'claimant': f'{p.name}-{p.instance_uuid}'})
+        await p._do_work(lta_rc_mock)
+    lta_rc_mock.request.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=DESY&status=transferring', {'claimant': f'{p.name}-{p.instance_uuid}'})
 
 
 @pytest.mark.asyncio
 async def test_desy_move_verifier_do_work_no_results(config: TestConfig, mocker: MockerFixture) -> None:
     """Test that _do_work goes on vacation when the LTA DB has no work."""
     logger_mock = mocker.MagicMock()
+    lta_rc_mock = AsyncMock()
     dwc_mock = mocker.patch("lta.desy_move_verifier.DesyMoveVerifier._do_work_claim", new_callable=AsyncMock)
     dwc_mock.return_value = False
     p = DesyMoveVerifier(config, logger_mock)
-    await p._do_work()
+    await p._do_work(lta_rc_mock)
     dwc_mock.assert_called()
 
 
@@ -200,10 +202,11 @@ async def test_desy_move_verifier_do_work_no_results(config: TestConfig, mocker:
 async def test_desy_move_verifier_do_work_yes_results(config: TestConfig, mocker: MockerFixture) -> None:
     """Test that _do_work keeps working until the LTA DB has no work."""
     logger_mock = mocker.MagicMock()
+    lta_rc_mock = AsyncMock()
     dwc_mock = mocker.patch("lta.desy_move_verifier.DesyMoveVerifier._do_work_claim", new_callable=AsyncMock)
     dwc_mock.side_effect = [True, True, False]
     p = DesyMoveVerifier(config, logger_mock)
-    await p._do_work()
+    await p._do_work(lta_rc_mock)
     dwc_mock.assert_called()
 
 
@@ -211,14 +214,15 @@ async def test_desy_move_verifier_do_work_yes_results(config: TestConfig, mocker
 async def test_desy_move_verifier_do_work_claim_no_result(config: TestConfig, mocker: MockerFixture) -> None:
     """Test that _do_work_claim does not work when the LTA DB has no work."""
     logger_mock = mocker.MagicMock()
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.return_value = {
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.return_value = {
         "bundle": None
     }
     vb_mock = mocker.patch("lta.desy_move_verifier.DesyMoveVerifier._verify_bundle", new_callable=AsyncMock)
     p = DesyMoveVerifier(config, logger_mock)
-    await p._do_work_claim()
-    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=DESY&status=transferring', {'claimant': f'{p.name}-{p.instance_uuid}'})
+    await p._do_work_claim(lta_rc_mock)
+    lta_rc_mock.request.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=DESY&status=transferring', {'claimant': f'{p.name}-{p.instance_uuid}'})
     vb_mock.assert_not_called()
 
 
@@ -226,16 +230,17 @@ async def test_desy_move_verifier_do_work_claim_no_result(config: TestConfig, mo
 async def test_desy_move_verifier_do_work_claim_yes_result(config: TestConfig, mocker: MockerFixture) -> None:
     """Test that _do_work_claim processes the Bundle that it gets from the LTA DB."""
     logger_mock = mocker.MagicMock()
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.return_value = {
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.return_value = {
         "bundle": {
             "one": 1,
         },
     }
     vb_mock = mocker.patch("lta.desy_move_verifier.DesyMoveVerifier._verify_bundle", new_callable=AsyncMock)
     p = DesyMoveVerifier(config, logger_mock)
-    assert await p._do_work_claim()
-    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=DESY&status=transferring', {'claimant': f'{p.name}-{p.instance_uuid}'})
+    assert await p._do_work_claim(lta_rc_mock)
+    lta_rc_mock.request.assert_called_with("POST", '/Bundles/actions/pop?source=WIPAC&dest=DESY&status=transferring', {'claimant': f'{p.name}-{p.instance_uuid}'})
     vb_mock.assert_called_with(mocker.ANY, {"one": 1})
 
 

--- a/tests/test_nersc_retriever.py
+++ b/tests/test_nersc_retriever.py
@@ -210,7 +210,7 @@ async def test_nersc_retriever_do_work_no_results(config: TestConfig, mocker: Mo
     dwc_mock = mocker.patch("lta.nersc_retriever.NerscRetriever._do_work_claim", new_callable=AsyncMock)
     dwc_mock.return_value = False
     p = NerscRetriever(config, logger_mock)
-    await p._do_work()
+    await p._do_work(AsyncMock())
     dwc_mock.assert_called()
 
 
@@ -221,7 +221,7 @@ async def test_nersc_retriever_do_work_yes_results(config: TestConfig, mocker: M
     dwc_mock = mocker.patch("lta.nersc_retriever.NerscRetriever._do_work_claim", new_callable=AsyncMock)
     dwc_mock.side_effect = [True, True, False]
     p = NerscRetriever(config, logger_mock)
-    await p._do_work()
+    await p._do_work(AsyncMock())
     dwc_mock.assert_called()
 
 
@@ -237,7 +237,7 @@ async def test_nersc_retriever_hpss_not_available(config: TestConfig, mocker: Mo
         stderr="some text on stderr",
     )
     p = NerscRetriever(config, logger_mock)
-    assert not await p._do_work_claim()
+    assert not await p._do_work_claim(AsyncMock())
 
 
 @pytest.mark.asyncio
@@ -251,14 +251,15 @@ async def test_nersc_retriever_do_work_pop_exception(config: TestConfig, mocker:
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.side_effect = [
         HTTPError(500, "LTA DB on fire. Again.")
     ]
     p = NerscRetriever(config, logger_mock)
     with pytest.raises(HTTPError):
-        await p._do_work()
-    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=NERSC&dest=WIPAC&status=located', {'claimant': f'{p.name}-{p.instance_uuid}'})
+        await p._do_work(lta_rc_mock)
+    lta_rc_mock.request.assert_called_with("POST", '/Bundles/actions/pop?source=NERSC&dest=WIPAC&status=located', {'claimant': f'{p.name}-{p.instance_uuid}'})
 
 
 @pytest.mark.asyncio
@@ -272,16 +273,17 @@ async def test_nersc_retriever_do_work_claim_no_result(config: TestConfig, mocke
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.side_effect = [
         {
             "bundle": None
         }
     ]
     wbth_mock = mocker.patch("lta.nersc_retriever.NerscRetriever._read_bundle_from_hpss", new_callable=AsyncMock)
     p = NerscRetriever(config, logger_mock)
-    await p._do_work_claim()
-    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=NERSC&dest=WIPAC&status=located', {'claimant': f'{p.name}-{p.instance_uuid}'})
+    await p._do_work_claim(lta_rc_mock)
+    lta_rc_mock.request.assert_called_with("POST", '/Bundles/actions/pop?source=NERSC&dest=WIPAC&status=located', {'claimant': f'{p.name}-{p.instance_uuid}'})
     wbth_mock.assert_not_called()
 
 
@@ -296,8 +298,9 @@ async def test_nersc_retriever_do_work_claim_yes_result(config: TestConfig, mock
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.side_effect = [
         {
             "bundle": {
                 "one": 1,
@@ -306,8 +309,8 @@ async def test_nersc_retriever_do_work_claim_yes_result(config: TestConfig, mock
     ]
     wbth_mock = mocker.patch("lta.nersc_retriever.NerscRetriever._read_bundle_from_hpss", new_callable=AsyncMock)
     p = NerscRetriever(config, logger_mock)
-    await p._do_work_claim()
-    lta_rc_mock.assert_called_with("POST", '/Bundles/actions/pop?source=NERSC&dest=WIPAC&status=located', {'claimant': f'{p.name}-{p.instance_uuid}'})
+    await p._do_work_claim(lta_rc_mock)
+    lta_rc_mock.request.assert_called_with("POST", '/Bundles/actions/pop?source=NERSC&dest=WIPAC&status=located', {'claimant': f'{p.name}-{p.instance_uuid}'})
     wbth_mock.assert_called_with(mocker.ANY, {"one": 1})
 
 
@@ -322,8 +325,9 @@ async def test_nersc_retriever_do_work_claim_write_bundle_raise_exception(config
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.side_effect = [
         {
             "bundle": {
                 "uuid": "8f03a920-49d6-446b-811e-830e3f7942f5",
@@ -334,8 +338,8 @@ async def test_nersc_retriever_do_work_claim_write_bundle_raise_exception(config
     wbth_mock = mocker.patch("lta.nersc_retriever.NerscRetriever._read_bundle_from_hpss", new_callable=AsyncMock)
     wbth_mock.side_effect = Exception("BAD THING HAPPEN!")
     p = NerscRetriever(config, logger_mock)
-    assert not await p._do_work_claim()
-    lta_rc_mock.assert_called_with("PATCH", '/Bundles/8f03a920-49d6-446b-811e-830e3f7942f5', mocker.ANY)
+    assert not await p._do_work_claim(lta_rc_mock)
+    lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/8f03a920-49d6-446b-811e-830e3f7942f5', mocker.ANY)
     wbth_mock.assert_called_with(mocker.ANY, {"uuid": "8f03a920-49d6-446b-811e-830e3f7942f5"})
 
 
@@ -350,8 +354,9 @@ async def test_nersc_retriever_read_bundle_from_hpss_hsi_get(config: TestConfig,
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    request_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    request_mock.side_effect = [
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.side_effect = [
         {
             "bundle": {
                 "uuid": "398ca1ed-0178-4333-a323-8b9158c3dd88",
@@ -366,9 +371,9 @@ async def test_nersc_retriever_read_bundle_from_hpss_hsi_get(config: TestConfig,
     ehc_mock = mocker.patch("lta.nersc_retriever.NerscRetriever._execute_hsi_command", new_callable=AsyncMock)
     ehc_mock.side_effect = [True, False]
     p = NerscRetriever(config, logger_mock)
-    await p._do_work_claim()
+    await p._do_work_claim(lta_rc_mock)
     ehc_mock.assert_called_with(mocker.ANY, mocker.ANY, ['/usr/bin/hsi', 'get', '-c', 'on', '/path/to/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip', ':', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'])
-    request_mock.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
+    lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
 
 
 @pytest.mark.asyncio
@@ -382,8 +387,9 @@ async def test_nersc_retriever_read_bundle_from_hpss(config: TestConfig, mocker:
         stdout="some text on stdout",
         stderr="some text on stderr",
     )
-    request_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    request_mock.side_effect = [
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.side_effect = [
         {
             "bundle": {
                 "uuid": "398ca1ed-0178-4333-a323-8b9158c3dd88",
@@ -398,9 +404,9 @@ async def test_nersc_retriever_read_bundle_from_hpss(config: TestConfig, mocker:
     ehc_mock = mocker.patch("lta.nersc_retriever.NerscRetriever._execute_hsi_command", new_callable=AsyncMock)
     ehc_mock.side_effect = [True, True]
     p = NerscRetriever(config, logger_mock)
-    await p._do_work_claim()
+    await p._do_work_claim(lta_rc_mock)
     ehc_mock.assert_called_with(mocker.ANY, mocker.ANY, ['/usr/bin/hsi', 'get', '-c', 'on', '/path/to/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip', ':', '/path/to/hpss/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'])
-    request_mock.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
+    lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
 
 
 @pytest.mark.asyncio
@@ -422,8 +428,9 @@ async def test_nersc_retriever_execute_hsi_command_failed(config: TestConfig, mo
             stderr="some text on stderr",
         )
     ]
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.side_effect = [
         {
             "bundle": {
                 "uuid": "398ca1ed-0178-4333-a323-8b9158c3dd88",
@@ -436,8 +443,8 @@ async def test_nersc_retriever_execute_hsi_command_failed(config: TestConfig, mo
         },
     ]
     p = NerscRetriever(config, logger_mock)
-    await p._do_work_claim()
-    lta_rc_mock.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
+    await p._do_work_claim(lta_rc_mock)
+    lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
 
 
 @pytest.mark.asyncio
@@ -455,9 +462,9 @@ async def test_nersc_retriever_execute_hsi_command_success(config: TestConfig, m
         ObjectLiteral(returncode=0),
         ObjectLiteral(returncode=0)
     ]
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock = mocker.patch("rest_tools.client.RestClient.request", new_callable=AsyncMock)
-    lta_rc_mock.side_effect = [
+    lta_rc_mock = AsyncMock()
+    lta_rc_mock.request = AsyncMock()
+    lta_rc_mock.request.side_effect = [
         {
             "bundle": {
                 "uuid": "398ca1ed-0178-4333-a323-8b9158c3dd88",
@@ -470,5 +477,5 @@ async def test_nersc_retriever_execute_hsi_command_success(config: TestConfig, m
         },
     ]
     p = NerscRetriever(config, logger_mock)
-    await p._do_work_claim()
-    lta_rc_mock.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
+    await p._do_work_claim(lta_rc_mock)
+    lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)


### PR DESCRIPTION
@vbrik reached out on Slack because LTA was making a lot of requests to the Keycloak service.

Some of this is unavoidable; there are 10 components in a transfer pipeline, and all of them need to talk to the LTA REST service in order to coordinate their work.

Also, at peak times (retro disk processing) there can be 16-32 instances of some components like bundler and gridftp_replicator.

NERSC's slurm based job system is not great for long-lived components, so depending on how aggressively these components at scheduled at NERSC, they will start up frequently and authenticate with keycloak every time.

However, there are some improvements that can be made to the code. Instead of authenticating with keycloak at every work cycle, the RestClient can be created when the component is started, and the client can re-use its existing token, and only refresh it when necessary.

This PR introduces the code changes needed to create the RestClient early and provide it to the component to enable re-use.

A similar issue may affect the RestClient the component uses to access the File Catalog. Fortunately, these requests to authenticate with Keycloak should only happen when actual work is being performed. If these are also very noisy, we may consider earlier creation of this resource as well.