### PR TITLE
Elasticsearch token url

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,15 +6,15 @@
 #
 binpacking==1.5.2
     # via lta (setup.py)
-cachetools==5.5.0
+cachetools==5.5.1
     # via wipac-rest-tools
-certifi==2024.8.30
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
-click==8.1.7
+click==8.1.8
     # via
     #   click-completion
     #   pycycle
@@ -26,13 +26,13 @@ colorama==0.4.6
     #   lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-coverage[toml]==7.6.7
+coverage[toml]==7.6.12
     # via pytest-cov
 crayons==0.4.0
     # via pycycle
-cryptography==43.0.3
+cryptography==44.0.1
     # via pyjwt
-deprecated==1.2.15
+deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-http
@@ -49,7 +49,7 @@ googleapis-common-protos==1.56.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.68.0
+grpcio==1.70.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -61,19 +61,19 @@ importlib-metadata==8.5.0
     # via opentelemetry-api
 iniconfig==2.0.0
     # via pytest
-jinja2==3.1.4
+jinja2==3.1.5
     # via click-completion
 markupsafe==3.0.2
     # via jinja2
 mccabe==0.7.0
     # via flake8
-motor==3.6.0
+motor==3.7.0
     # via lta (setup.py)
-mypy==1.13.0
+mypy==1.15.0
     # via lta (setup.py)
 mypy-extensions==1.0.0
     # via mypy
-opentelemetry-api==1.28.2
+opentelemetry-api==1.30.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
@@ -87,29 +87,29 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.28.2
+opentelemetry-exporter-otlp-proto-common==1.30.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.28.2
+opentelemetry-exporter-otlp-proto-http==1.30.0
     # via wipac-telemetry
-opentelemetry-proto==1.28.2
+opentelemetry-proto==1.30.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.28.2
+opentelemetry-sdk==1.30.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.49b2
+opentelemetry-semantic-conventions==0.51b0
     # via opentelemetry-sdk
 packaging==24.2
     # via pytest
 pluggy==1.5.0
     # via pytest
-prometheus-client==0.21.0
+prometheus-client==0.21.1
     # via lta (setup.py)
-protobuf==5.28.3
+protobuf==5.29.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -122,20 +122,20 @@ pycycle==0.0.8
     # via lta (setup.py)
 pyflakes==3.2.0
     # via flake8
-pyjwt[crypto]==2.10.0
+pyjwt[crypto]==2.10.1
     # via wipac-rest-tools
-pymongo==4.9.2
+pymongo==4.11.1
     # via
     #   lta (setup.py)
     #   motor
-pytest==8.3.3
+pytest==8.3.4
     # via
     #   lta (setup.py)
     #   pycycle
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
-pytest-asyncio==0.24.0
+pytest-asyncio==0.25.3
     # via lta (setup.py)
 pytest-cov==6.0.0
     # via lta (setup.py)
@@ -154,13 +154,13 @@ requests-futures==1.0.2
     # via wipac-rest-tools
 shellingham==1.5.4
     # via click-completion
-six==1.16.0
+six==1.17.0
     # via
     #   click-completion
     #   thrift
 thrift==0.21.0
     # via opentelemetry-exporter-jaeger-thrift
-tomli==2.1.0
+tomli==2.2.1
     # via
     #   coverage
     #   mypy
@@ -179,21 +179,21 @@ typing-extensions==4.12.2
     #   opentelemetry-sdk
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   requests
     #   types-requests
     #   wipac-rest-tools
-wipac-dev-tools==1.13.0
+wipac-dev-tools==1.15.1
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.8.2
+wipac-rest-tools==1.8.5
     # via lta (setup.py)
 wipac-telemetry==0.3.1
     # via lta (setup.py)
-wrapt==1.17.0
+wrapt==1.17.2
     # via deprecated
 zipp==3.21.0
     # via importlib-metadata

--- a/requirements-monitoring.txt
+++ b/requirements-monitoring.txt
@@ -4,35 +4,35 @@
 #
 #    pip-compile --extra=monitoring --output-file=requirements-monitoring.txt
 #
-aiohappyeyeballs==2.4.3
+aiohappyeyeballs==2.4.6
     # via aiohttp
-aiohttp==3.11.7
+aiohttp==3.11.12
     # via elasticsearch
-aiosignal==1.3.1
+aiosignal==1.3.2
     # via aiohttp
 async-timeout==5.0.1
     # via aiohttp
-attrs==24.2.0
+attrs==25.1.0
     # via aiohttp
 binpacking==1.5.2
     # via lta (setup.py)
-cachetools==5.5.0
+cachetools==5.5.1
     # via wipac-rest-tools
-certifi==2024.8.30
+certifi==2025.1.31
     # via
     #   elasticsearch
     #   requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 colorama==0.4.6
     # via lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==43.0.3
+cryptography==44.0.1
     # via pyjwt
-deprecated==1.2.15
+deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-http
@@ -51,7 +51,7 @@ googleapis-common-protos==1.56.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.68.0
+grpcio==1.70.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -63,13 +63,13 @@ idna==3.10
     #   yarl
 importlib-metadata==8.5.0
     # via opentelemetry-api
-motor==3.6.0
+motor==3.7.0
     # via lta (setup.py)
 multidict==6.1.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.28.2
+opentelemetry-api==1.30.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
@@ -83,38 +83,38 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.28.2
+opentelemetry-exporter-otlp-proto-common==1.30.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.28.2
+opentelemetry-exporter-otlp-proto-http==1.30.0
     # via wipac-telemetry
-opentelemetry-proto==1.28.2
+opentelemetry-proto==1.30.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.28.2
+opentelemetry-sdk==1.30.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.49b2
+opentelemetry-semantic-conventions==0.51b0
     # via opentelemetry-sdk
-prometheus-client==0.21.0
+prometheus-client==0.21.1
     # via lta (setup.py)
-propcache==0.2.0
+propcache==0.2.1
     # via
     #   aiohttp
     #   yarl
-protobuf==5.28.3
+protobuf==5.29.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   wipac-telemetry
 pycparser==2.22
     # via cffi
-pyjwt[crypto]==2.10.0
+pyjwt[crypto]==2.10.1
     # via wipac-rest-tools
-pymongo==4.9.2
+pymongo==4.11.1
     # via
     #   lta (setup.py)
     #   motor
@@ -128,7 +128,7 @@ requests==2.32.3
     #   wipac-rest-tools
 requests-futures==1.0.2
     # via wipac-rest-tools
-six==1.16.0
+six==1.17.0
     # via thrift
 thrift==0.21.0
     # via opentelemetry-exporter-jaeger-thrift
@@ -142,23 +142,23 @@ typing-extensions==4.12.2
     #   opentelemetry-sdk
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   elasticsearch
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.13.0
+wipac-dev-tools==1.15.1
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.8.2
+wipac-rest-tools==1.8.5
     # via lta (setup.py)
 wipac-telemetry==0.3.1
     # via lta (setup.py)
-wrapt==1.17.0
+wrapt==1.17.2
     # via deprecated
-yarl==1.18.0
+yarl==1.18.3
     # via
     #   aiohttp
     #   elasticsearch

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,21 +6,21 @@
 #
 binpacking==1.5.2
     # via lta (setup.py)
-cachetools==5.5.0
+cachetools==5.5.1
     # via wipac-rest-tools
-certifi==2024.8.30
+certifi==2025.1.31
     # via requests
 cffi==1.17.1
     # via cryptography
-charset-normalizer==3.4.0
+charset-normalizer==3.4.1
     # via requests
 colorama==0.4.6
     # via lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==43.0.3
+cryptography==44.0.1
     # via pyjwt
-deprecated==1.2.15
+deprecated==1.2.18
     # via
     #   opentelemetry-api
     #   opentelemetry-exporter-otlp-proto-http
@@ -33,7 +33,7 @@ googleapis-common-protos==1.56.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.68.0
+grpcio==1.70.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -43,9 +43,9 @@ idna==3.10
     # via requests
 importlib-metadata==8.5.0
     # via opentelemetry-api
-motor==3.6.0
+motor==3.7.0
     # via lta (setup.py)
-opentelemetry-api==1.28.2
+opentelemetry-api==1.30.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
@@ -59,34 +59,34 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.28.2
+opentelemetry-exporter-otlp-proto-common==1.30.0
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.28.2
+opentelemetry-exporter-otlp-proto-http==1.30.0
     # via wipac-telemetry
-opentelemetry-proto==1.28.2
+opentelemetry-proto==1.30.0
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.28.2
+opentelemetry-sdk==1.30.0
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.49b2
+opentelemetry-semantic-conventions==0.51b0
     # via opentelemetry-sdk
-prometheus-client==0.21.0
+prometheus-client==0.21.1
     # via lta (setup.py)
-protobuf==5.28.3
+protobuf==5.29.3
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
     #   wipac-telemetry
 pycparser==2.22
     # via cffi
-pyjwt[crypto]==2.10.0
+pyjwt[crypto]==2.10.1
     # via wipac-rest-tools
-pymongo==4.9.2
+pymongo==4.11.1
     # via
     #   lta (setup.py)
     #   motor
@@ -100,7 +100,7 @@ requests==2.32.3
     #   wipac-rest-tools
 requests-futures==1.0.2
     # via wipac-rest-tools
-six==1.16.0
+six==1.17.0
     # via thrift
 thrift==0.21.0
     # via opentelemetry-exporter-jaeger-thrift
@@ -113,20 +113,20 @@ typing-extensions==4.12.2
     #   opentelemetry-sdk
     #   wipac-dev-tools
     #   wipac-telemetry
-urllib3==2.2.3
+urllib3==2.3.0
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.13.0
+wipac-dev-tools==1.15.1
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.8.2
+wipac-rest-tools==1.8.5
     # via lta (setup.py)
 wipac-telemetry==0.3.1
     # via lta (setup.py)
-wrapt==1.17.0
+wrapt==1.17.2
     # via deprecated
 zipp==3.21.0
     # via importlib-metadata

--- a/resources/progress_to_es.py
+++ b/resources/progress_to_es.py
@@ -187,6 +187,8 @@ def main():
         'FILE_CATALOG_URL': 'https://file-catalog.icecube.wisc.edu',
         'ES_ADDRESS': 'https://elastic.icecube.aq',
         'ES_INDEX': 'long-term-archive',
+        'ES_CLIENT_ID': 'elasticsearch',
+        'ES_CLIENT_SECRET': '',
         'ES_TIMEOUT': 60.,
         'START_DATE': '',
         'END_DATE': '',
@@ -203,21 +205,15 @@ def main():
     parser.add_argument('-n', '--dry-run', default=False, action='store_true',
                         help='do not ingest into ES, just print')
     parser.add_argument('--log-level', default='info', choices=['debug', 'info', 'warning', 'error'])
-    parser.add_argument('--es_client_id',default=None,
-                        help='ES oauth2 client id')
-    parser.add_argument('--es_client_secret',default=None,
-                        help='ES oauth2 client secret')
-    parser.add_argument('--token_url',default=None,
-                        help='ES oauth2 realm token url')
     args = parser.parse_args()
 
     logging.basicConfig(level=getattr(logging, args.log_level.upper()), format='%(asctime)s %(levelname)s %(name)s : %(message)s')
 
     es_api = ClientCredentialsAuth(
         address=config['ES_ADDRESS'],
-        token_url=args.token_url,
-        client_secret=args.es_client_secret,
-        client_id=args.es_client_id
+        token_url=config['OPENID_URL'],
+        client_secret=config['ES_CLIENT_SECRET'],
+        client_id=config['ES_CLIENT_ID']
     )
     es_token = es_api.make_access_token()
 


### PR DESCRIPTION
The progress dump to elasticsearch job in kubernetes was failing due missing some env vars for the token creation. This change should fix taht.