### PR TITLE
Remove old MongoDB versions from CI workflow

### DIFF
--- a/.github/workflows/wipac_cicd.yml
+++ b/.github/workflows/wipac_cicd.yml
@@ -69,7 +69,7 @@ jobs:
       fail-fast: false
       matrix:
         py3: ${{ fromJSON(needs.py-versions.outputs.matrix) }}
-        mongodb-version: [3.6, 4.0, 4.2, 4.4, 5.0, 6.0]
+        mongodb-version: [4.2, 4.4, 5.0, 6.0]
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
During #283 @alemsh pointed out some failing CI workflows.

Turns out, the newest version of PyMongo requires MongoDB v4+.

The instance of MongoDB backing LTA is currently running 4.2:
```
    spec:
      containers:
      - name: {{ .Values.spec.name }}-mongo
        image: bitnami/mongodb:4.2
```

So this PR removes 3.6 and 4.0 from the strategy matrix of the CI workflow.
It's very unlikely that we'll decide to downgrade MongoDB to an older (and now incompatible) version, so we'll stop testing against them.
This should make our CI checks happy for awhile.
