### PR TITLE
Add architecture request to sbatch call in NERSC controller

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@
 #
 binpacking==1.5.2
     # via lta (setup.py)
-cachetools==5.5.1
+cachetools==5.5.2
     # via wipac-rest-tools
 certifi==2025.1.31
     # via requests
@@ -26,11 +26,11 @@ colorama==0.4.6
     #   lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-coverage[toml]==7.6.12
+coverage[toml]==7.7.1
     # via pytest-cov
 crayons==0.4.0
     # via pycycle
-cryptography==44.0.1
+cryptography==44.0.2
     # via pyjwt
 deprecated==1.2.18
     # via
@@ -49,7 +49,7 @@ googleapis-common-protos==1.56.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.70.0
+grpcio==1.71.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -57,11 +57,11 @@ hurry-filesize==0.9
     # via lta (setup.py)
 idna==3.10
     # via requests
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via opentelemetry-api
-iniconfig==2.0.0
+iniconfig==2.1.0
     # via pytest
-jinja2==3.1.5
+jinja2==3.1.6
     # via click-completion
 markupsafe==3.0.2
     # via jinja2
@@ -73,7 +73,7 @@ mypy==1.15.0
     # via lta (setup.py)
 mypy-extensions==1.0.0
     # via mypy
-opentelemetry-api==1.30.0
+opentelemetry-api==1.31.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
@@ -87,21 +87,21 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.30.0
+opentelemetry-exporter-otlp-proto-common==1.31.1
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.30.0
+opentelemetry-exporter-otlp-proto-http==1.31.1
     # via wipac-telemetry
-opentelemetry-proto==1.30.0
+opentelemetry-proto==1.31.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.30.0
+opentelemetry-sdk==1.31.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.51b0
+opentelemetry-semantic-conventions==0.52b1
     # via opentelemetry-sdk
 packaging==24.2
     # via pytest
@@ -109,7 +109,7 @@ pluggy==1.5.0
     # via pytest
 prometheus-client==0.21.1
     # via lta (setup.py)
-protobuf==5.29.3
+protobuf==5.29.4
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -124,18 +124,18 @@ pyflakes==3.2.0
     # via flake8
 pyjwt[crypto]==2.10.1
     # via wipac-rest-tools
-pymongo==4.11.1
+pymongo==4.11.3
     # via
     #   lta (setup.py)
     #   motor
-pytest==8.3.4
+pytest==8.3.5
     # via
     #   lta (setup.py)
     #   pycycle
     #   pytest-asyncio
     #   pytest-cov
     #   pytest-mock
-pytest-asyncio==0.25.3
+pytest-asyncio==0.26.0
     # via lta (setup.py)
 pytest-cov==6.0.0
     # via lta (setup.py)
@@ -171,9 +171,9 @@ tornado==6.4.2
     #   wipac-rest-tools
 types-colorama==0.4.15.20240311
     # via lta (setup.py)
-types-requests==2.32.0.20241016
+types-requests==2.32.0.20250306
     # via lta (setup.py)
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   mypy
     #   opentelemetry-sdk
@@ -184,12 +184,12 @@ urllib3==2.3.0
     #   requests
     #   types-requests
     #   wipac-rest-tools
-wipac-dev-tools==1.15.2
+wipac-dev-tools==1.15.6
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.8.5
+wipac-rest-tools==1.8.6
     # via lta (setup.py)
 wipac-telemetry==0.3.1
     # via lta (setup.py)

--- a/requirements-monitoring.txt
+++ b/requirements-monitoring.txt
@@ -4,19 +4,19 @@
 #
 #    pip-compile --extra=monitoring --output-file=requirements-monitoring.txt
 #
-aiohappyeyeballs==2.4.6
+aiohappyeyeballs==2.6.1
     # via aiohttp
-aiohttp==3.11.12
+aiohttp==3.11.14
     # via elasticsearch
 aiosignal==1.3.2
     # via aiohttp
 async-timeout==5.0.1
     # via aiohttp
-attrs==25.1.0
+attrs==25.3.0
     # via aiohttp
 binpacking==1.5.2
     # via lta (setup.py)
-cachetools==5.5.1
+cachetools==5.5.2
     # via wipac-rest-tools
 certifi==2025.1.31
     # via
@@ -30,7 +30,7 @@ colorama==0.4.6
     # via lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==44.0.1
+cryptography==44.0.2
     # via pyjwt
 deprecated==1.2.18
     # via
@@ -39,7 +39,7 @@ deprecated==1.2.18
     #   opentelemetry-semantic-conventions
 dnspython==2.7.0
     # via pymongo
-elastic-transport==8.17.0
+elastic-transport==8.17.1
     # via elasticsearch
 elasticsearch[async]==8.15.1
     # via lta (setup.py)
@@ -53,7 +53,7 @@ googleapis-common-protos==1.56.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.70.0
+grpcio==1.71.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -63,15 +63,15 @@ idna==3.10
     # via
     #   requests
     #   yarl
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via opentelemetry-api
 motor==3.7.0
     # via lta (setup.py)
-multidict==6.1.0
+multidict==6.2.0
     # via
     #   aiohttp
     #   yarl
-opentelemetry-api==1.30.0
+opentelemetry-api==1.31.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
@@ -85,29 +85,29 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.30.0
+opentelemetry-exporter-otlp-proto-common==1.31.1
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.30.0
+opentelemetry-exporter-otlp-proto-http==1.31.1
     # via wipac-telemetry
-opentelemetry-proto==1.30.0
+opentelemetry-proto==1.31.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.30.0
+opentelemetry-sdk==1.31.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.51b0
+opentelemetry-semantic-conventions==0.52b1
     # via opentelemetry-sdk
 prometheus-client==0.21.1
     # via lta (setup.py)
-propcache==0.2.1
+propcache==0.3.1
     # via
     #   aiohttp
     #   yarl
-protobuf==5.29.3
+protobuf==5.29.4
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -116,7 +116,7 @@ pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.10.1
     # via wipac-rest-tools
-pymongo==4.11.1
+pymongo==4.11.3
     # via
     #   lta (setup.py)
     #   motor
@@ -138,7 +138,7 @@ tornado==6.4.2
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   multidict
     #   opentelemetry-sdk
@@ -149,12 +149,12 @@ urllib3==2.3.0
     #   elastic-transport
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.15.2
+wipac-dev-tools==1.15.6
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.8.5
+wipac-rest-tools==1.8.6
     # via lta (setup.py)
 wipac-telemetry==0.3.1
     # via lta (setup.py)

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 #
 binpacking==1.5.2
     # via lta (setup.py)
-cachetools==5.5.1
+cachetools==5.5.2
     # via wipac-rest-tools
 certifi==2025.1.31
     # via requests
@@ -18,7 +18,7 @@ colorama==0.4.6
     # via lta (setup.py)
 coloredlogs==15.0.1
     # via wipac-telemetry
-cryptography==44.0.1
+cryptography==44.0.2
     # via pyjwt
 deprecated==1.2.18
     # via
@@ -33,7 +33,7 @@ googleapis-common-protos==1.56.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-otlp-proto-http
-grpcio==1.70.0
+grpcio==1.71.0
     # via opentelemetry-exporter-jaeger-proto-grpc
 humanfriendly==10.0
     # via coloredlogs
@@ -41,11 +41,11 @@ hurry-filesize==0.9
     # via lta (setup.py)
 idna==3.10
     # via requests
-importlib-metadata==8.5.0
+importlib-metadata==8.6.1
     # via opentelemetry-api
 motor==3.7.0
     # via lta (setup.py)
-opentelemetry-api==1.30.0
+opentelemetry-api==1.31.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
@@ -59,25 +59,25 @@ opentelemetry-exporter-jaeger-proto-grpc==1.21.0
     # via opentelemetry-exporter-jaeger
 opentelemetry-exporter-jaeger-thrift==1.21.0
     # via opentelemetry-exporter-jaeger
-opentelemetry-exporter-otlp-proto-common==1.30.0
+opentelemetry-exporter-otlp-proto-common==1.31.1
     # via opentelemetry-exporter-otlp-proto-http
-opentelemetry-exporter-otlp-proto-http==1.30.0
+opentelemetry-exporter-otlp-proto-http==1.31.1
     # via wipac-telemetry
-opentelemetry-proto==1.30.0
+opentelemetry-proto==1.31.1
     # via
     #   opentelemetry-exporter-otlp-proto-common
     #   opentelemetry-exporter-otlp-proto-http
-opentelemetry-sdk==1.30.0
+opentelemetry-sdk==1.31.1
     # via
     #   opentelemetry-exporter-jaeger-proto-grpc
     #   opentelemetry-exporter-jaeger-thrift
     #   opentelemetry-exporter-otlp-proto-http
     #   wipac-telemetry
-opentelemetry-semantic-conventions==0.51b0
+opentelemetry-semantic-conventions==0.52b1
     # via opentelemetry-sdk
 prometheus-client==0.21.1
     # via lta (setup.py)
-protobuf==5.29.3
+protobuf==5.29.4
     # via
     #   googleapis-common-protos
     #   opentelemetry-proto
@@ -86,7 +86,7 @@ pycparser==2.22
     # via cffi
 pyjwt[crypto]==2.10.1
     # via wipac-rest-tools
-pymongo==4.11.1
+pymongo==4.11.3
     # via
     #   lta (setup.py)
     #   motor
@@ -108,7 +108,7 @@ tornado==6.4.2
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
-typing-extensions==4.12.2
+typing-extensions==4.13.0
     # via
     #   opentelemetry-sdk
     #   wipac-dev-tools
@@ -117,12 +117,12 @@ urllib3==2.3.0
     # via
     #   requests
     #   wipac-rest-tools
-wipac-dev-tools==1.15.2
+wipac-dev-tools==1.15.6
     # via
     #   lta (setup.py)
     #   wipac-rest-tools
     #   wipac-telemetry
-wipac-rest-tools==1.8.5
+wipac-rest-tools==1.8.6
     # via lta (setup.py)
 wipac-telemetry==0.3.1
     # via lta (setup.py)

--- a/resources/nersc_controller.py
+++ b/resources/nersc_controller.py
@@ -91,12 +91,13 @@ def add_job_to_slurm_queue(context: Context, name: str) -> None:
     # run the sacct command to determine our jobs currently running in the slurm queue
     #     sbatch_path            The path to the 'sbatch' command
     #     --account=m1093        IceCube's project (m1093) at NERSC
+    #     --constraint=cron      'Requested policies require the cron architecture'
     #     --output=slurm.log     The log file used by the job
     #     --qos=xfer             Add the job to the xfer queue
     #     --time=HH:MM:SS        Time limit for the job
     #     --time-min=HH:MM:SS    Minimum time for the job
     #     name.sh                The script to be run in the slurm queue
-    args = [sbatch_path, "--account=m1093", f"--output={slurm_log_dir}/slurm-{name}-%j.out", "--qos=xfer", f"--time={job_time}", f"--time-min={job_time_min}", f"{lta_bin_dir}/{name}.sh"]
+    args = [sbatch_path, "--account=m1093", "--constraint=cron", f"--output={slurm_log_dir}/slurm-{name}-%j.out", "--qos=xfer", f"--time={job_time}", f"--time-min={job_time_min}", f"{lta_bin_dir}/{name}.sh"]
     LOG.info(f"Running command: {args}")
     completed_process = run(args, stdout=PIPE, stderr=PIPE)
 


### PR DESCRIPTION
At NERSC, they use the SLURM system to schedule workflows on their compute nodes.

LTA uses an `scrontab` script to specify that a controller script (`nersc_controller.py`) be run on a regular basis.

This controller script in turn queries the SLURM job system to determine how many LTA components are currently running (or scheduled to be run) at NERSC.

If more components are needed to perform work, the controller script will run the `sbatch` command to create a new job in the workflow queue.

Until the NERSC maintenance on 2025-03-26, these `sbatch` commands were executing correctly, adding jobs to the queue, and LTA was working properly.

After the maintenance was complete and the systems came back, the `sbatch` command started returning errors:

```text
2025-03-27 12:15:09,040 [MainThread] INFO  (nersc_controller.py:100) - Running command: ['/usr/bin/sbatch', '--account=m1093', '--output=/global/homes/i/icecubed/lta/slurm-logs/slurm-pipe0-nersc-deleter-%j.out', '--qos=xfer', '--time=12:00:00', '--time-min=6:00:00', '/global/homes/i/icecubed/lta/bin/pipe0-nersc-deleter.sh']
2025-03-27 12:15:09,258 [MainThread] ERROR (nersc_controller.py:105) - Command to add a job to the slurm queue failed
2025-03-27 12:15:09,258 [MainThread] INFO  (nersc_controller.py:106) - Command: ['/usr/bin/sbatch', '--account=m1093', '--output=/global/homes/i/icecubed/lta/slurm-logs/slurm-pipe0-nersc-deleter-%j.out', '--qos=xfer', '--time=12:00:00', '--time-min=6:00:00', '/global/homes/i/icecubed/lta/bin/pipe0-nersc-deleter.sh']
2025-03-27 12:15:09,258 [MainThread] INFO  (nersc_controller.py:107) - returncode: 1
2025-03-27 12:15:09,258 [MainThread] INFO  (nersc_controller.py:108) - stdout: b''
2025-03-27 12:15:09,258 [MainThread] INFO  (nersc_controller.py:109) - stderr: b'sbatch: error: No architecture specified, cannot estimate job costs.\nsbatch: error: Batch job submission failed: Unspecified error\n'
```

Unable to schedule jobs, I did some searching and eventually found some documentation at NERSC explaining the problem and the solution:

https://docs.nersc.gov/jobs/troubleshooting/

I tried an interactive use of the `sbatch` command with the flag suggested in the FAQ (`-C cpu` became `--constraint=cpu`), but I got an error with that as well:

```text
(env) icecubed@perlmutter:login40:~/lta> /usr/bin/sbatch --account=m1093 --constraint=cpu --output=/global/homes/i/icecubed/lta/slurm-logs/slurm-pipe0-nersc-mover-interactive$(date +%s).out --qos=xfer --time=12:00:00 --time-min=6:00:00 /global/homes/i/icecubed/lta/bin/pipe0-nersc-mover.sh
sbatch: error: Requested policies require the cron architecture, but you have requested cpu. Rejecting request.
sbatch: error: Batch job submission failed: Unspecified error
```

So here we are now; modifying the `nersc_controller.py` script to specify `--constraint=cron` so that we can submit jobs to the slurm queue.