### PR TITLE
Removed type Argument From create_token Call in Unit Tests

### DIFF
--- a/lta/version.py
+++ b/lta/version.py
@@ -17,5 +17,5 @@ __version__: str
 __version_tuple__: VERSION_TUPLE
 version_tuple: VERSION_TUPLE
 
-__version__ = version = '0.42.10.dev1+g452179a.d20250714'
-__version_tuple__ = version_tuple = (0, 42, 10, 'dev1', 'g452179a.d20250714')
+__version__ = version = '0.42.10.dev2+g7dc770a.d20250721'
+__version_tuple__ = version_tuple = (0, 42, 10, 'dev2', 'g7dc770a.d20250721')

--- a/tests/test_rest_server.py
+++ b/tests/test_rest_server.py
@@ -106,7 +106,6 @@ async def rest(monkeypatch: MonkeyPatch, port: int) -> AsyncGenerator[RestClient
         logging.info("setting role to %s", role)
         token = auth.create_token(subject="lta",  # type: ignore[no-untyped-call]
                                   expiration=300,
-                                  type="temp",
                                   payload=token_data,
                                   headers=None)
         return RestClient(f'http://localhost:{port}', token=token, timeout=timeout, retries=0)


### PR DESCRIPTION
Parameter `type` was removed from `create_token()` in https://github.com/WIPACrepo/rest-tools/pull/163
This PR updates the unit tests for the LTA REST server to not supply that argument anymore.
