### PR TITLE
Calculate Bundle File Size at Source

### DIFF
--- a/lta/desy_mirror_replicator.py
+++ b/lta/desy_mirror_replicator.py
@@ -149,6 +149,7 @@ class DesyMirrorReplicator(Component):
         # create Sync to transfer to DESY
         sync = Sync(self.config)
         try:
+            LOG.info(f"Replicating {bundle_path} -> {dest_path}")
             await sync.put_path(bundle_path, dest_path)
         except Exception as e:
             self.logger.error(f'DESY Sync raised an Exception: {e}')

--- a/lta/transfer/sync.py
+++ b/lta/transfer/sync.py
@@ -16,6 +16,8 @@ import pycurl
 from rest_tools.client import ClientCredentialsAuth
 from tornado.httpclient import AsyncHTTPClient, HTTPError, HTTPRequest
 
+LOG = logging.getLogger(__name__)
+
 DataDict = dict[str, Any]
 
 P = ParamSpec("P")
@@ -484,7 +486,7 @@ class Sync(ParallelAsync):
         uploadpath = fullpath.with_name('_upload_' + fullpath.name)
         self.rc._get_token()
         token = _decode_if_necessary(self.rc.access_token)
-        filesize = Path(dest_path).stat(follow_symlinks=True).st_size
+        filesize = Path(src_path).stat(follow_symlinks=True).st_size
         headers = {
             'Authorization': f'bearer {token}',
             'Content-Length': str(filesize),
@@ -567,5 +569,7 @@ class Sync(ParallelAsync):
         file to the final location.
         """
         dest_dir = str(Path(dest_path).parent)
+        LOG.info(f"Ensuring {dest_dir} exists at destination")
         await self.mkdir_p(dest_dir, int(self.config["WORK_TIMEOUT_SECONDS"]))
+        LOG.info(f"Uploading {src_path} -> {dest_path}")
         await self.put_file_src_dest(src_path, dest_path, timeout)


### PR DESCRIPTION
This PR fixes a small bug where we try to get the size of the file at the destination path instead of the source path.
This, of course, leads to a `No such file or directory` error:
```
2025-08-08 20:00:51,530 [MainThread] ERROR (desy_mirror_replicator.py:154) - DESY Sync raised an Exception: [Errno 2] No such file or directory: '/data/exp/IceCube/2023/filtered/PFFilt/0101/392f684e6e2611f0860c6a88b6417bb6.zip'
```

It also adds a little additional logging, just to make things clear.
