### PR TITLE
Comment out unsetopt calls for setup_curl

### DIFF
--- a/lta/transfer/sync.py
+++ b/lta/transfer/sync.py
@@ -297,7 +297,7 @@ class Sync(ParallelAsync):
                 setup_curl = bind_setup_curl(self.config)
                 setup_curl(c)
                 if filesize >= 2000000000:
-                    c.unsetopt(pycurl.INFILESIZE)
+                    # c.unsetopt(pycurl.INFILESIZE)
                     c.setopt(pycurl.INFILESIZE_LARGE, filesize)
                 else:
                     c.setopt(pycurl.INFILESIZE, filesize)
@@ -506,7 +506,7 @@ class Sync(ParallelAsync):
                 setup_curl = bind_setup_curl(self.config)
                 setup_curl(c)
                 if filesize >= 2000000000:
-                    c.unsetopt(pycurl.INFILESIZE)
+                    # c.unsetopt(pycurl.INFILESIZE)
                     c.setopt(pycurl.INFILESIZE_LARGE, filesize)
                 else:
                     c.setopt(pycurl.INFILESIZE, filesize)


### PR DESCRIPTION
Got an error trying to replicate a bundle:
```
2025-08-11 18:38:31,292 [MainThread] ERROR (desy_mirror_replicator.py:155) - DESY Sync raised an Exception: unsetopt() is not supported for this option
```

There are only two `unsetopt()` calls and it relates to the file size. In my case, the bundle is 78645938923 bytes (78.6 GB) which is larger than the 2000000000 bytes (2 GB) that will trigger the path using the `unsetopt()` call.

It looks like pycurl doesn't like us calling unsetopt on that option (`INFILESIZE`). So we'll just call setopt() on the one we want (`INFILESIZE_LARGE`) see if that works.

The split between INFILESIZE and INFILESIZE_LARGE looks like a type issue in libcurl. My guess is (signed) `long` on a 32-bit system goes up to 2147483647 (2.1 GB), beyond that you're looking at negative values. So when files got bigger, they needed an option that will allow a larger size to be specified without breaking binary compatibility for the older call.

See: https://curl.se/libcurl/c/CURLOPT_INFILESIZE.html
