### PR TITLE
Refactor work timeout in DESY Mirror Replicator

### DIFF
--- a/lta/desy_mirror_replicator.py
+++ b/lta/desy_mirror_replicator.py
@@ -150,7 +150,7 @@ class DesyMirrorReplicator(Component):
         sync = Sync(self.config)
         try:
             LOG.info(f"Replicating {bundle_path} -> {dest_path}")
-            await sync.put_path(bundle_path, dest_path)
+            await sync.put_path(bundle_path, dest_path, self.work_timeout_seconds)
         except Exception as e:
             self.logger.error(f'DESY Sync raised an Exception: {e}')
             raise e

--- a/lta/desy_mirror_replicator.py
+++ b/lta/desy_mirror_replicator.py
@@ -150,7 +150,7 @@ class DesyMirrorReplicator(Component):
         sync = Sync(self.config)
         try:
             LOG.info(f"Replicating {bundle_path} -> {dest_path}")
-            await sync.put_path(bundle_path, dest_path, self.work_timeout_seconds)
+            await sync.put_path(bundle_path, dest_path, int(self.work_timeout_seconds))
         except Exception as e:
             self.logger.error(f'DESY Sync raised an Exception: {e}')
             raise e

--- a/lta/transfer/sync.py
+++ b/lta/transfer/sync.py
@@ -574,6 +574,6 @@ class Sync(ParallelAsync):
         """
         dest_dir = str(Path(dest_path).parent)
         LOG.info(f"Ensuring {dest_dir} exists at destination")
-        await self.mkdir_p(dest_dir, int(self.config["WORK_TIMEOUT_SECONDS"]))
+        await self.mkdir_p(dest_dir, timeout)
         LOG.info(f"Uploading {src_path} -> {dest_path}")
         await self.put_file_src_dest(src_path, dest_path, timeout)

--- a/lta/transfer/sync.py
+++ b/lta/transfer/sync.py
@@ -101,7 +101,6 @@ class Sync(ParallelAsync):
     Original code by David Schultz; gently adapted for LTA by Patrick Meade.
     """
     def __init__(self, config: dict[str, str]):
-        # self._semaphore = asyncio.Semaphore(int(config["MAX_PARALLEL"]))
         super().__init__(int(config["MAX_PARALLEL"]))
 
         self.config = config
@@ -494,7 +493,7 @@ class Sync(ParallelAsync):
             'Expect': '100-continue',
         }
         # give ourselves a minimum of 10 minutes per GB
-        timeout = max(timeout, int(filesize / 10**9)*600)
+        timeout = max(timeout, int(filesize / 10**9) * 600)
 
         with open(src_path, 'rb') as f:
             def seek(offset: int, _origin: int) -> int:

--- a/resources/make_lta_token.py
+++ b/resources/make_lta_token.py
@@ -43,7 +43,7 @@ def run():
 
     # show me the money!
     rc = ClientCredentialsAuth(
-        address=f"http://localhost:8080/",
+        address="http://localhost:8080/",
         token_url=config["AUTH_OPENID_URL"],
         client_id=config["CLIENT_ID"],
         client_secret=config["CLIENT_SECRET"],

--- a/resources/webdav_proxy.py
+++ b/resources/webdav_proxy.py
@@ -103,16 +103,36 @@ class WebDAVProxy(BaseHTTPRequestHandler):
         except Exception as e:
             self.send_error(502, f"Bad gateway: {e}")
 
-    def do_GET(self): self.do_common()
-    def do_PUT(self): self.do_common()
-    def do_PROPFIND(self): self.do_common()
-    def do_MKCOL(self): self.do_common()
-    def do_DELETE(self): self.do_common()
-    def do_COPY(self): self.do_common()
-    def do_MOVE(self): self.do_common()
-    def do_OPTIONS(self): self.do_common()
-    def do_HEAD(self): self.do_common()
-    def do_POST(self): self.do_common()
+    def do_GET(self):
+        self.do_common()
+
+    def do_PUT(self):
+        self.do_common()
+
+    def do_PROPFIND(self):
+        self.do_common()
+
+    def do_MKCOL(self):
+        self.do_common()
+
+    def do_DELETE(self):
+        self.do_common()
+
+    def do_COPY(self):
+        self.do_common()
+
+    def do_MOVE(self):
+        self.do_common()
+
+    def do_OPTIONS(self):
+        self.do_common()
+
+    def do_HEAD(self):
+        self.do_common()
+
+    def do_POST(self):
+        self.do_common()
+
 
 def run():
     # obtain our configuration from the environment
@@ -134,6 +154,7 @@ def run():
     except KeyboardInterrupt:
         print("Shutting down.")
         server.server_close()
+
 
 if __name__ == "__main__":
     run()

--- a/tests/test_desy_mirror_replicator.py
+++ b/tests/test_desy_mirror_replicator.py
@@ -403,7 +403,8 @@ async def test_desy_mirror_replicator_replicate_bundle_to_destination_site_raise
     await p._do_work_claim(lta_rc_mock)
     sync_class_mock.return_value.put_path.assert_called_with(
         '/path/on/source/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip',
-        '/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'
+        '/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip',
+        30
     )
     lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)
 
@@ -431,6 +432,7 @@ async def test_desy_mirror_replicator_replicate_bundle_to_destination_site(confi
     await p._do_work_claim(lta_rc_mock)
     sync_class_mock.return_value.put_path.assert_called_with(
         '/path/on/source/rse/398ca1ed-0178-4333-a323-8b9158c3dd88.zip',
-        '/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip'
+        '/data/exp/IceCube/2019/filtered/PFFilt/1109/398ca1ed-0178-4333-a323-8b9158c3dd88.zip',
+        30
     )
     lta_rc_mock.request.assert_called_with("PATCH", '/Bundles/398ca1ed-0178-4333-a323-8b9158c3dd88', mocker.ANY)

--- a/tests/test_transfer_sync.py
+++ b/tests/test_transfer_sync.py
@@ -1032,7 +1032,7 @@ async def test_sync_put_path(config: TestConfig, mocker: MockerFixture) -> None:
 
     await sync.put_path("9c0ccadf-6d21-4dae-aba5-38750f0d22ec.zip", "/fake/data/exp/IceCube/2050/unbiased/PFRaw/1109/9c0ccadf-6d21-4dae-aba5-38750f0d22ec.zip")
 
-    mdp_mock.assert_called_with("/fake/data/exp/IceCube/2050/unbiased/PFRaw/1109", 30)
+    mdp_mock.assert_called_with("/fake/data/exp/IceCube/2050/unbiased/PFRaw/1109", 1200)
     pfsd_mock.assert_called_with(
         "9c0ccadf-6d21-4dae-aba5-38750f0d22ec.zip",
         "/fake/data/exp/IceCube/2050/unbiased/PFRaw/1109/9c0ccadf-6d21-4dae-aba5-38750f0d22ec.zip",


### PR DESCRIPTION
Just a small cleanup for how timeouts propagate downstream:
- Stops the lower level Sync class from reaching up to the config for a timeout value
- Makes the higher level DESY Mirror Replicator explicitly pass the config'd timeout value

The alternative size-based timeout minimum is hard-coded and not really documented except in the code.
It does show up in the logs, so I'll cut bait and leave it here instead of clogging up the config with more things to understand.
