### PR TITLE
Adds --clear-transfer-reference Flag to ltacmd bundle update-status

### DIFF
--- a/lta/lta_cmd.py
+++ b/lta/lta_cmd.py
@@ -379,7 +379,7 @@ async def bundle_update_status(args: Namespace) -> ExitCode:
     patch_body["reason"] = ""
     patch_body["update_timestamp"] = right_now
     if args.clear_transfer_reference:
-        patch_body["transfer_reference"] = "re-globus-for-testing"
+        patch_body["transfer_reference"] = "re-globus"
     if not args.keep_claim:
         patch_body["claimed"] = False
     if not args.keep_priority:


### PR DESCRIPTION
We'll need to clear the `transfer_reference` field in a Bundle document, in order to force the Globus Replicator to try again before the default deadline kills the transfer. This is mostly useful for debugging and testing, but may have an operator intervention case in limited circumstances.

```
{
    "bundle_path": "/data/user/jade/ltatemp/bundler_out/55376cb8ece711f0ae044ebd8fff1e7a.zip",
    "checksum": {
        "adler32": "7a0c41ef",
        "sha512": "8491d105f2b08fba774e1486a1589028d5e8c69102ed09e6662d5dbee8cd97ff2bbbd00aa226f007dc149f9220f049a0ae228921daa0d23f4bf10b33c49a3fb0"
    },
    "claim_timestamp": "2026-01-09T00:22:59",
    "claimant": "long-term-archive-pipe0-globus-replicator-6ccbfb97c6-nwbsh-b7266b80-7ae7-4102-843d-d362d9c86016",
    "claimed": true,
    "create_timestamp": "2026-01-08T23:11:15",
    "dest": "NERSC",
    "file_count": 1239,
    "path": "/data/exp/IceCube/2026/filtered/PFFilt/0102",
    "reason": "",
    "request": "3ea38d74ece711f0ae044ebd8fff1e7a",
    "size": 107380502078,
    "source": "WIPAC",
    "status": "staged",
    "transfer_reference": "globus/5a582361-ecf1-11f0-8cfd-0eb0b913a0ab",
    "type": "Bundle",
    "update_timestamp": "2026-01-09T00:23:01",
    "uuid": "55376cb8ece711f0ae044ebd8fff1e7a",
    "verified": false,
    "work_priority_timestamp": "2026-01-08T23:11:15"
}
```

This PR adds a `--clear-transfer-reference` flag to the `ltacmd bundle update-status` command.
When provided, the `transfer_reference` field will be patched to `""`.

It looks like Globus Replicator will treat an empty string as a None / null / empty:
https://github.com/WIPACrepo/lta/blob/main/lta/globus_replicator.py#L52

So this PR should allow the operators to clear that field when it is necessary to do so.
